### PR TITLE
Enable guest cart functionality

### DIFF
--- a/libreria/src/main/java/com/api/libreria/model/Cart.java
+++ b/libreria/src/main/java/com/api/libreria/model/Cart.java
@@ -19,6 +19,8 @@ public class Cart {
 
     private Long usuarioId;
 
+    private String guestId;
+
     @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CartItem> items;
 }

--- a/libreria/src/main/java/com/api/libreria/repository/CartRepository.java
+++ b/libreria/src/main/java/com/api/libreria/repository/CartRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
     Optional<Cart> findByUsuarioId(Long usuarioId);
+
+    Optional<Cart> findByGuestId(String guestId);
 }

--- a/libreria/src/main/java/com/api/libreria/security/SecurityConfig.java
+++ b/libreria/src/main/java/com/api/libreria/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/books/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/ofertas/**").permitAll()
+                .requestMatchers("/api/cart/**").permitAll()
                 // rutas protegidas
                 .requestMatchers("/api/books/**").hasRole("ADMIN")
                 .requestMatchers("/api/ofertas/**").hasRole("ADMIN")

--- a/libreria/src/main/java/com/api/libreria/service/CartService.java
+++ b/libreria/src/main/java/com/api/libreria/service/CartService.java
@@ -19,17 +19,26 @@ public class CartService {
         this.userRepository = userRepository;
     }
 
-    public Cart getOrCreateCart(Long userId) {
-        return cartRepository.findByUsuarioId(userId)
-                .orElseGet(() -> {
-                    Cart newCart = new Cart();
-                    newCart.setUsuarioId(userId);
-                    return cartRepository.save(newCart);
-                });
+    public Cart getOrCreateCart(Long userId, String guestId) {
+        if (userId != null) {
+            return cartRepository.findByUsuarioId(userId)
+                    .orElseGet(() -> {
+                        Cart newCart = new Cart();
+                        newCart.setUsuarioId(userId);
+                        return cartRepository.save(newCart);
+                    });
+        } else {
+            return cartRepository.findByGuestId(guestId)
+                    .orElseGet(() -> {
+                        Cart newCart = new Cart();
+                        newCart.setGuestId(guestId);
+                        return cartRepository.save(newCart);
+                    });
+        }
     }
 
-    public Cart addItemToCart(Long userId, Book book, Integer quantity) {
-        Cart cart = getOrCreateCart(userId);
+    public Cart addItemToCart(Long userId, String guestId, Book book, Integer quantity) {
+        Cart cart = getOrCreateCart(userId, guestId);
 
         Optional<CartItem> existingItem = cart.getItems() == null ? Optional.empty() :
             cart.getItems().stream().filter(item -> item.getBook().getId().equals(book.getId())).findFirst();
@@ -47,11 +56,14 @@ public class CartService {
             cartItemRepository.save(item);
         }
 
-        return cartRepository.findByUsuarioId(userId).orElse(cart);
+        if (userId != null) {
+            return cartRepository.findByUsuarioId(userId).orElse(cart);
+        }
+        return cartRepository.findByGuestId(guestId).orElse(cart);
     }
 
-    public Cart updateItemQuantity(Long userId, Long itemId, Integer quantity) {
-        Cart cart = getOrCreateCart(userId);
+    public Cart updateItemQuantity(Long userId, String guestId, Long itemId, Integer quantity) {
+        Cart cart = getOrCreateCart(userId, guestId);
 
         CartItem item = cartItemRepository.findById(itemId)
                 .orElseThrow(() -> new RuntimeException("Item no encontrado"));
@@ -67,11 +79,14 @@ public class CartService {
             cartItemRepository.save(item);
         }
 
-        return cartRepository.findByUsuarioId(userId).orElse(cart);
+        if (userId != null) {
+            return cartRepository.findByUsuarioId(userId).orElse(cart);
+        }
+        return cartRepository.findByGuestId(guestId).orElse(cart);
     }
 
-    public Cart removeItemFromCart(Long userId, Long itemId) {
-        Cart cart = getOrCreateCart(userId);
+    public Cart removeItemFromCart(Long userId, String guestId, Long itemId) {
+        Cart cart = getOrCreateCart(userId, guestId);
 
         CartItem item = cartItemRepository.findById(itemId)
                 .orElseThrow(() -> new RuntimeException("Item no encontrado"));
@@ -82,6 +97,9 @@ public class CartService {
 
         cartItemRepository.delete(item);
 
-        return cartRepository.findByUsuarioId(userId).orElse(cart);
+        if (userId != null) {
+            return cartRepository.findByUsuarioId(userId).orElse(cart);
+        }
+        return cartRepository.findByGuestId(guestId).orElse(cart);
     }
 }


### PR DESCRIPTION
## Summary
- allow `/api/cart/**` endpoints for both authenticated and unauthenticated users
- add `guestId` field to carts
- support guest carts in controller and service
- expose `/api/cart/**` as public route in security config

## Testing
- `./mvnw -q test` *(fails: repository fetch blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68538fe1df348325b3f55492dd795579