### PR TITLE
Align Java API names with frontend types

### DIFF
--- a/libreria/src/main/java/com/api/libreria/controller/AuthController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/AuthController.java
@@ -28,15 +28,15 @@ public class AuthController {
 
     @PostMapping("/register")
     public ResponseEntity<?> register(@RequestBody RegisterRequest request) {
-        if (userRepository.findByUsername(request.getUsername()).isPresent()) {
-            return ResponseEntity.badRequest().body("Username already exists");
+        if (userRepository.findByNombre(request.getNombre()).isPresent()) {
+            return ResponseEntity.badRequest().body("Nombre de usuario ya existe");
         }
 
         User user = new User();
-        user.setUsername(request.getUsername());
+        user.setNombre(request.getNombre());
         user.setEmail(request.getEmail());
         user.setPassword(passwordEncoder.encode(request.getPassword()));
-        user.setRole("USER"); // default role
+        user.setRol("USER"); // default role
 
         userRepository.save(user);
         return ResponseEntity.ok("User registered successfully");

--- a/libreria/src/main/java/com/api/libreria/controller/BookController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/BookController.java
@@ -46,14 +46,14 @@ public class BookController {
         Book existing = bookRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Libro no encontrado"));
 
-        existing.setTitle(request.getTitle());
-        existing.setAuthor(request.getAuthor());
+        existing.setTitulo(request.getTitulo());
+        existing.setAutor(request.getAutor());
         existing.setEditorial(request.getEditorial());
-        existing.setCategory(request.getCategory());
-        existing.setPrice(request.getPrice());
+        existing.setCategoria(request.getCategoria());
+        existing.setPrecio(request.getPrecio());
         existing.setStock(request.getStock());
-        existing.setDescription(request.getDescription());
-        existing.setImageUrl(request.getImageUrl());
+        existing.setDescripcion(request.getDescripcion());
+        existing.setCoverImage(request.getCoverImage());
 
         Book updated = bookRepository.save(existing);
         return ResponseEntity.ok(updated);

--- a/libreria/src/main/java/com/api/libreria/controller/CartController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/CartController.java
@@ -108,7 +108,7 @@ public class CartController {
             CartItem item = new CartItem();
             item.setBook(book);
             item.setCantidad(cantidad);
-            item.setPrecioUnitario(book.getPrice());
+            item.setPrecioUnitario(book.getPrecio());
             item.setCart(cart);
             cartItemRepository.save(item);
         }
@@ -213,7 +213,7 @@ public class CartController {
         return builder.body(cart);
     }
 
-    private Long getUserId(String username) {
-        return userRepository.findByUsername(username).orElseThrow().getId();
+    private Long getUserId(String nombre) {
+        return userRepository.findByNombre(nombre).orElseThrow().getId();
     }
 }

--- a/libreria/src/main/java/com/api/libreria/controller/UserController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/UserController.java
@@ -44,7 +44,7 @@ public class UserController {
 
     @GetMapping("/perfil")
     public ResponseEntity<User> getProfile(@AuthenticationPrincipal UserDetails userDetails) {
-        return userService.getUserByUsername(userDetails.getUsername())
+        return userService.getUserByNombre(userDetails.getUsername())
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/libreria/src/main/java/com/api/libreria/controller/VentaController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/VentaController.java
@@ -43,7 +43,7 @@ public class VentaController {
         return ventaRepository.findByUsuarioId(userId, pageable);
     }
 
-    private Long getUserId(String username) {
-        return userRepository.findByUsername(username).orElseThrow().getId();
+    private Long getUserId(String nombre) {
+        return userRepository.findByNombre(nombre).orElseThrow().getId();
     }
 }

--- a/libreria/src/main/java/com/api/libreria/dto/RegisterRequest.java
+++ b/libreria/src/main/java/com/api/libreria/dto/RegisterRequest.java
@@ -4,7 +4,7 @@ import lombok.Data;
 
 @Data
 public class RegisterRequest {
-    private String username;
+    private String nombre;
     private String email;
     private String password;
 }

--- a/libreria/src/main/java/com/api/libreria/model/Book.java
+++ b/libreria/src/main/java/com/api/libreria/model/Book.java
@@ -18,24 +18,20 @@ public class Book {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String title;
+    private String titulo;
 
-    private String author;
+    private String autor;
 
     private String editorial;
 
-    private String category;
+    private String categoria;
 
-    private Double price;
+    private Double precio;
 
     private Integer stock;
 
     @Column(length = 2000)
-    private String description;
+    private String descripcion;
 
-    private String imageUrl;
-
-    public void setTitulo(String titulo) {
-        throw new UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody
-    }
+    private String coverImage;
 }

--- a/libreria/src/main/java/com/api/libreria/model/OrderItem.java
+++ b/libreria/src/main/java/com/api/libreria/model/OrderItem.java
@@ -24,7 +24,8 @@ public class OrderItem {
     @JoinColumn(name = "book_id")
     private Book book;
 
-    private Integer quantity;
+    private Integer cantidad;
 
-    private Double price;  // Precio en el momento de la compra
+    // Precio en el momento de la compra
+    private Double precioUnitario;
 }

--- a/libreria/src/main/java/com/api/libreria/model/User.java
+++ b/libreria/src/main/java/com/api/libreria/model/User.java
@@ -16,11 +16,12 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String username;
+    // nombre de usuario o nombre público
+    private String nombre;
 
     private String email;
 
     private String password; // luego esto será hasheado
 
-    private String role; // Ej: "USER" o "ADMIN"
+    private String rol; // Ej: "USER" o "ADMIN"
 }

--- a/libreria/src/main/java/com/api/libreria/repository/UserRepository.java
+++ b/libreria/src/main/java/com/api/libreria/repository/UserRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByUsername(String username);
+    Optional<User> findByNombre(String nombre);
 
     Optional<User> findByEmail(String email);
 }

--- a/libreria/src/main/java/com/api/libreria/security/CustomUserDetailsService.java
+++ b/libreria/src/main/java/com/api/libreria/security/CustomUserDetailsService.java
@@ -19,15 +19,15 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) {
         System.out.println("username = " + username);
-        User user = userRepository.findByUsername(username)
+        User user = userRepository.findByNombre(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User Not Found"));
 
         log.info("user: " + user);
         
         return org.springframework.security.core.userdetails.User.builder()
-                .username(user.getUsername())
+                .username(user.getNombre())
                 .password(user.getPassword())
-                .roles(user.getRole())
+                .roles(user.getRol())
                 .build();
     }
 

--- a/libreria/src/main/java/com/api/libreria/service/CartService.java
+++ b/libreria/src/main/java/com/api/libreria/service/CartService.java
@@ -52,7 +52,7 @@ public class CartService {
             item.setCart(cart);
             item.setBook(book);
             item.setCantidad(quantity);
-            item.setPrecioUnitario(book.getPrice());
+            item.setPrecioUnitario(book.getPrecio());
             cartItemRepository.save(item);
         }
 

--- a/libreria/src/main/java/com/api/libreria/service/OrderService.java
+++ b/libreria/src/main/java/com/api/libreria/service/OrderService.java
@@ -52,8 +52,8 @@ public class OrderService {
             OrderItem orderItem = new OrderItem();
             orderItem.setOrder(order);
             orderItem.setBook(item.getBook());
-            orderItem.setQuantity(item.getCantidad());
-            orderItem.setPrice(item.getPrecioUnitario());
+            orderItem.setCantidad(item.getCantidad());
+            orderItem.setPrecioUnitario(item.getPrecioUnitario());
             orderItemRepository.save(orderItem);
 
             total += item.getCantidad() * item.getPrecioUnitario();

--- a/libreria/src/main/java/com/api/libreria/service/UserService.java
+++ b/libreria/src/main/java/com/api/libreria/service/UserService.java
@@ -25,8 +25,8 @@ public class UserService {
         return userRepository.findById(id);
     }
 
-    public Optional<User> getUserByUsername(String username) {
-        return userRepository.findByUsername(username);
+    public Optional<User> getUserByNombre(String nombre) {
+        return userRepository.findByNombre(nombre);
     }
 
     public User saveUser(User user) {

--- a/libreria/src/main/java/com/api/libreria/service/VentaService.java
+++ b/libreria/src/main/java/com/api/libreria/service/VentaService.java
@@ -41,7 +41,7 @@ public class VentaService  {
         // Validar stock
         for (CartItem item : cart.getItems()) {
             if (item.getBook().getStock() < item.getCantidad()) {
-                throw new RuntimeException("Stock insuficiente para: " + item.getBook().getTitle());
+                throw new RuntimeException("Stock insuficiente para: " + item.getBook().getTitulo());
             }
         }
 


### PR DESCRIPTION
## Summary
- update backend entity and DTO field names to match frontend Spanish naming
- propagate new names through repositories, services, controllers and security components

## Testing
- `npm run lint` *(fails: next not found)*
- `mvn -q -DskipTests package` *(fails: mvn: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543b1d977883258ffcb304a2b7e13d