### PR TITLE
Fix select value and unwrap route params

### DIFF
--- a/studio/src/app/[lang]/admin/panel/books/components/book-form-client.tsx
+++ b/studio/src/app/[lang]/admin/panel/books/components/book-form-client.tsx
@@ -241,14 +241,18 @@ export function BookFormClient({ book, onSave, lang, isLoadingExternally }: Book
                   <FormField control={form.control} name="editorialId" render={({ field }) => (
                     <FormItem>
                       <FormLabel>Publisher (Optional)</FormLabel>
-                      <Select onValueChange={field.onChange} value={field.value || ''} defaultValue={field.value || ''}>
+                      <Select
+                        onValueChange={(value) => field.onChange(value === 'none' ? null : value)}
+                        value={field.value ?? 'none'}
+                        defaultValue={field.value ?? 'none'}
+                      >
                         <FormControl>
                           <SelectTrigger>
                             <SelectValue placeholder="Select a publisher" />
                           </SelectTrigger>
                         </FormControl>
                         <SelectContent>
-                          <SelectItem value="">No Publisher</SelectItem>
+                          <SelectItem value="none">No Publisher</SelectItem>
                           {editorials.map((editorial) => (
                             <SelectItem key={editorial.id} value={String(editorial.id)}>
                               {editorial.nombre}

--- a/studio/src/app/[lang]/admin/panel/books/page.tsx
+++ b/studio/src/app/[lang]/admin/panel/books/page.tsx
@@ -1,7 +1,7 @@
 
 "use client"; 
 
-import { useState, useEffect, Suspense } from 'react';
+import React, { useState, useEffect, Suspense, use } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import type { Book } from '@/types';
 import { BookFormClient } from './components/book-form-client';
@@ -14,10 +14,11 @@ import { useToast } from '@/hooks/use-toast';
 // Removed mock data and functions
 
 interface ManageBooksContentProps {
-  params: { lang: string };
+  params: { lang: string } | Promise<{ lang: string }>;
 }
 
-function ManageBooksContent({ params: { lang } }: ManageBooksContentProps) {
+function ManageBooksContent({ params }: ManageBooksContentProps) {
+  const { lang } = use(params);
   const searchParams = useSearchParams();
   const router = useRouter();
   const { toast } = useToast();

--- a/studio/src/app/[lang]/admin/panel/categories/components/manage-categories-content.tsx
+++ b/studio/src/app/[lang]/admin/panel/categories/components/manage-categories-content.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import { useState, useEffect, useCallback } from 'react'; // Added useCallback
+import React, { useState, useEffect, useCallback, use } from 'react'; // Added useCallback
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import type { Category, ApiResponseError } from '@/types'; // Added ApiResponseError
 // Import actual API service functions
@@ -17,7 +17,7 @@ import { Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
 interface ManageCategoriesContentProps {
-  params: { lang: string }; // lang is now string, not string | undefined
+  params: { lang: string } | Promise<{ lang: string }>; // lang is now string, not string | undefined
   initialCategories: Category[];
   texts: any; // Dictionary texts for categories
 }
@@ -28,7 +28,7 @@ export function ManageCategoriesContent({ params, initialCategories, texts }: Ma
   const searchParams = useSearchParams();
   const { toast } = useToast();
 
-  const lang = params.lang; // Directly use lang from params
+  const { lang } = use(params); // Unwrap params
 
   const action = searchParams.get('action');
   const categoryId = searchParams.get('id');

--- a/studio/src/app/[lang]/admin/panel/editorials/components/manage-editorials-content.tsx
+++ b/studio/src/app/[lang]/admin/panel/editorials/components/manage-editorials-content.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import { useState, useEffect, useCallback } from 'react'; // Added useCallback
+import React, { useState, useEffect, useCallback, use } from 'react'; // Added useCallback
 import { useSearchParams, useRouter } from 'next/navigation';
 import type { Editorial, ApiResponseError } from '@/types'; // Added ApiResponseError
 // Import actual API service functions
@@ -17,7 +17,7 @@ import { Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast'; // Added useToast
 
 interface ManageEditorialsContentProps {
-  params: { lang: string }; // Changed lang to be a required string
+  params: { lang: string } | Promise<{ lang: string }>; // Changed lang to be a required string
   initialEditorials: Editorial[];
   texts: any;
 }
@@ -27,7 +27,7 @@ export function ManageEditorialsContent({ params, initialEditorials, texts }: Ma
   const searchParams = useSearchParams();
   const { toast } = useToast(); // Initialized useToast
 
-  const lang = params.lang; // Directly use lang from params
+  const { lang } = use(params); // Unwrap params
 
   const action = searchParams.get('action');
   const editorialId = searchParams.get('id');

--- a/studio/src/app/[lang]/admin/panel/offers/components/manage-offers-content.tsx
+++ b/studio/src/app/[lang]/admin/panel/offers/components/manage-offers-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, use } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import type { Offer, ApiResponseError, Book } from '@/types';
 import { 
@@ -17,7 +17,7 @@ import { Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
 interface ManageOffersContentProps {
-  params: { lang: string };
+  params: { lang: string } | Promise<{ lang: string }>;
   // initialOffers: Offer[]; // If passing server-fetched initial data
   texts: any; // Dictionary texts for offers
 }
@@ -26,7 +26,7 @@ export function ManageOffersContent({ params, texts }: ManageOffersContentProps)
   const router = useRouter();
   const searchParams = useSearchParams();
   const { toast } = useToast();
-  const lang = params.lang;
+  const { lang } = use(params);
 
   const action = searchParams.get('action');
   const offerId = searchParams.get('id');


### PR DESCRIPTION
## Summary
- ensure Radix Select doesn't use empty string values
- unwrap `params` using `use()` in several admin components to silence warnings

## Testing
- `npm --prefix studio test` *(fails: Missing script)*
- `npm --prefix studio run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685440ad34a08325b654f241d2ec3d2d