### PR TITLE
Fix categories prop mismatch

### DIFF
--- a/studio/src/app/[lang]/admin/panel/categories/components/manage-categories-content.tsx
+++ b/studio/src/app/[lang]/admin/panel/categories/components/manage-categories-content.tsx
@@ -18,11 +18,11 @@ import { useToast } from '@/hooks/use-toast';
 
 interface ManageCategoriesContentProps {
   params: { lang: string } | Promise<{ lang: string }>; // lang is now string, not string | undefined
-  initialCategories: Category[];
+  initialCategories?: Category[];
   texts: any; // Dictionary texts for categories
 }
 
-export function ManageCategoriesContent({ params, initialCategories, texts }: ManageCategoriesContentProps) {
+export function ManageCategoriesContent({ params, initialCategories = [], texts }: ManageCategoriesContentProps) {
   const router = useRouter();
   const pathname = usePathname(); // Retained for potential future use, but lang is primary
   const searchParams = useSearchParams();
@@ -152,7 +152,7 @@ export function ManageCategoriesContent({ params, initialCategories, texts }: Ma
 
   // Default to list view
   return <CategoryListClient
-            initialCategories={categories}
+            categories={categories}
             onDeleteCategory={handleDeleteCategory}
             lang={lang}
             texts={texts}


### PR DESCRIPTION
## Summary
- make `initialCategories` optional in `ManageCategoriesContent`
- pass `categories` prop correctly to `CategoryListClient`

## Testing
- `npm run typecheck` *(fails: Cannot find module...)*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854468792808325835c88c0d72615e6