### PR TITLE
Implement admin sales endpoints

### DIFF
--- a/libreria/src/main/java/com/api/libreria/controller/VentaController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/VentaController.java
@@ -4,6 +4,7 @@ import com.api.libreria.model.Venta;
 import com.api.libreria.repository.UserRepository;
 import com.api.libreria.repository.VentaRepository;
 import com.api.libreria.service.VentaService;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -41,6 +42,20 @@ public class VentaController {
                                  Pageable pageable) {
         Long userId = getUserId(userDetails.getUsername());
         return ventaRepository.findByUsuarioId(userId, pageable);
+    }
+
+    @GetMapping("/admin")
+    @PreAuthorize("hasRole('ADMIN')")
+    public List<Venta> getAllVentasAdmin() {
+        return ventaService.getAllVentas();
+    }
+
+    @GetMapping("/admin/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Venta> getVentaAdminById(@PathVariable Long id) {
+        return ventaService.getVentaById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
     }
 
     private Long getUserId(String nombre) {

--- a/libreria/src/main/java/com/api/libreria/security/SecurityConfig.java
+++ b/libreria/src/main/java/com/api/libreria/security/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                 // rutas protegidas
                 .requestMatchers("/api/books/**").hasRole("ADMIN")
                 .requestMatchers("/api/ofertas/**").hasRole("ADMIN")
+                .requestMatchers("/api/ventas/admin/**").hasRole("ADMIN")
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated()
             )

--- a/libreria/src/main/java/com/api/libreria/service/VentaService.java
+++ b/libreria/src/main/java/com/api/libreria/service/VentaService.java
@@ -81,4 +81,12 @@ public class VentaService  {
 
         return venta;
     }
+
+    public List<Venta> getAllVentas() {
+        return ventaRepository.findAll();
+    }
+
+    public Optional<Venta> getVentaById(Long id) {
+        return ventaRepository.findById(id);
+    }
 }


### PR DESCRIPTION
## Summary
- add service methods for fetching all sales
- expose `/api/ventas/admin` and `/api/ventas/admin/{id}` in `VentaController`
- secure the new endpoints in `SecurityConfig`

## Testing
- `./mvnw -q test` *(fails: could not fetch Maven due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_68544a0ebc708325bca279195caac372