### PR TITLE
Fix admin sales page params reference

### DIFF
--- a/studio/src/app/[lang]/admin/panel/sales/page.tsx
+++ b/studio/src/app/[lang]/admin/panel/sales/page.tsx
@@ -10,7 +10,8 @@ interface AdminSalesPageProps {
   params: any;
 }
 
-export default async function AdminSalesPage({ params: { lang } }: AdminSalesPageProps) {
+export default async function AdminSalesPage({ params }: AdminSalesPageProps) {
+  const { lang } = params;
   const dictionary = await getDictionary(lang);
   // Consolidate texts or ensure ManageSalesContent receives all it needs.
   // For simplicity, passing the salesPage part of dictionary, ManageSalesContent can use it.

--- a/studio/src/services/api.ts
+++ b/studio/src/services/api.ts
@@ -5,7 +5,10 @@ import type { Book, Category, Editorial, User, Cart, Sale, Offer, CreateSalePayl
 // Import mock functions
 import * as mockApi from '@/lib/mock-data';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+// Fallback to empty string so fetch uses a relative URL when the env variable
+// is not defined. This avoids runtime errors like `API call failed: {}` when
+// `NEXT_PUBLIC_API_BASE_URL` is missing during local development.
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '';
 // Correctly use the environment variable or default to 'production'
 const API_MODE = process.env.NEXT_PUBLIC_API_MODE || 'production'; 
 


### PR DESCRIPTION
## Summary
- fix use of params in admin sales page
- default `API_BASE_URL` to empty string so fetch uses relative paths

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*
- `./mvnw -q test` *(fails: network access for Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68545c58fcb88325b66dc199e269f8a3