### PR TITLE
Fix Next image configuration

### DIFF
--- a/studio/next.config.ts
+++ b/studio/next.config.ts
@@ -16,6 +16,12 @@ const nextConfig: NextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'example.com',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
   // The i18n object below is for the Pages Router and conflicts with


### PR DESCRIPTION
## Summary
- allow example.com images in next config to prevent errors

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685464a9cac08325a482d05b922d395e