### PR TITLE
Add env variable instructions

### DIFF
--- a/studio/.env.example
+++ b/studio/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for the Next.js frontend
+# Replace the URL with the address of your backend API
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
+# Select 'production' to use the real API or 'mock' to use local mock data
+NEXT_PUBLIC_API_MODE=production

--- a/studio/README.md
+++ b/studio/README.md
@@ -2,4 +2,24 @@
 
 This is a NextJS starter in Firebase Studio.
 
-To get started, take a look at src/app/page.tsx.
+To get started, take a look at `src/app/page.tsx`.
+
+## Configuración de la API
+
+El código utiliza dos variables de entorno para determinar cómo realizar las peticiones:
+
+- `NEXT_PUBLIC_API_BASE_URL`: URL base del backend (por ejemplo `http://localhost:8080`).
+- `NEXT_PUBLIC_API_MODE`: modo de la API, puede ser `production` o `mock`.
+
+En desarrollo puedes crear un archivo `.env.local` con las siguientes opciones:
+
+```env
+# Utiliza el backend real
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
+NEXT_PUBLIC_API_MODE=production
+
+# O utiliza los datos simulados sin backend
+# NEXT_PUBLIC_API_MODE=mock
+```
+
+Si estas variables no están definidas y el backend no está disponible, verás mensajes de error como `API call failed: {}` al iniciar la aplicación.


### PR DESCRIPTION
## Summary
- document how to configure `NEXT_PUBLIC_API_BASE_URL` and `NEXT_PUBLIC_API_MODE`
- add example `.env` file

## Testing
- `mvn -q test` *(fails: mvn not installed)*
- `npm run lint` in `studio` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546628a61c8325ab86c5dca60c4865