### PR TITLE
Enable file upload for book covers

### DIFF
--- a/libreria/src/main/java/com/api/libreria/config/WebConfig.java
+++ b/libreria/src/main/java/com/api/libreria/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.api.libreria.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:" + uploadDir + "/");
+    }
+}

--- a/libreria/src/main/resources/application.properties
+++ b/libreria/src/main/resources/application.properties
@@ -15,3 +15,4 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+file.upload-dir=uploads

--- a/studio/src/app/[lang]/admin/panel/books/page.tsx
+++ b/studio/src/app/[lang]/admin/panel/books/page.tsx
@@ -72,7 +72,7 @@ function ManageBooksContent({ params }: ManageBooksContentProps) {
     loadEditingBook();
   }, [action, bookId, lang, router, toast]);
 
-  const handleSaveBook = async (bookData: Partial<Book>) => { // Use Partial<Book> for payload
+  const handleSaveBook = async (bookData: Partial<Book> & { coverImageFile?: File }) => {
     setIsFormLoading(true);
     try {
       if (bookData.id) { // Existing book ID means update

--- a/studio/src/app/admin/books/page.tsx
+++ b/studio/src/app/admin/books/page.tsx
@@ -24,7 +24,7 @@ async function getAdminBookById(id: string): Promise<Book | undefined> {
   return new Promise(resolve => setTimeout(() => resolve(adminMockBooks.find(b => b.id === id)), 100));
 }
 
-async function saveAdminBook(bookData: Book): Promise<void> {
+async function saveAdminBook(bookData: Book & { coverImageFile?: File }): Promise<void> {
   return new Promise(resolve => {
     setTimeout(() => {
       const index = adminMockBooks.findIndex(b => b.id === bookData.id);

--- a/studio/src/lib/auth-utils.ts
+++ b/studio/src/lib/auth-utils.ts
@@ -1,9 +1,7 @@
 export const getAuthHeaders = (): Record<string, string> => {
   const token = typeof window !== 'undefined' ? localStorage.getItem('authToken') : null;
 
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
+  const headers: Record<string, string> = {};
 
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;


### PR DESCRIPTION
## Summary
- allow auth headers to be sent without forcing JSON content type
- support FormData bodies in API helper and send file uploads for book creation/update
- add cover image file field in book forms
- update admin panel logic to pass the uploaded file
- support storing uploaded book images on the server
- expose `/uploads/**` files via Spring resource handler

## Testing
- `mvnw test` *(fails: network access needed)*
- `npm run lint` *(fails: Next.js not installed)*
- `npm run typecheck` *(fails: Next.js not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855954af2948325b2a9c0eb81c59499