### PR TITLE
Align backend endpoints with frontend

### DIFF
--- a/libreria/src/main/java/com/api/libreria/controller/AuthController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/AuthController.java
@@ -48,6 +48,7 @@ public class AuthController {
                 new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
 
         String token = jwtUtils.generateJwtToken(request.getEmail());
-        return ResponseEntity.ok(new LoginResponse(token));
+        User user = userRepository.findByEmail(request.getEmail()).orElseThrow();
+        return ResponseEntity.ok(new LoginResponse(token, user));
     }
 }

--- a/libreria/src/main/java/com/api/libreria/controller/CartController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/CartController.java
@@ -2,6 +2,8 @@ package com.api.libreria.controller;
 
 import com.api.libreria.model.*;
 import com.api.libreria.repository.*;
+import com.api.libreria.dto.AddToCartRequest;
+import com.api.libreria.dto.UpdateCartItemRequest;
 import org.springframework.http.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -69,8 +71,10 @@ public class CartController {
     @PostMapping("/add")
     public ResponseEntity<Cart> addToCart(@AuthenticationPrincipal UserDetails userDetails,
             @RequestParam(required = false) String guestId,
-            @RequestParam Long bookId,
-            @RequestParam Integer cantidad) {
+            @RequestBody AddToCartRequest request) {
+
+        Long bookId = request.getLibroId();
+        Integer cantidad = request.getCantidad();
 
         Long userId = null;
         boolean newGuest = false;
@@ -134,7 +138,9 @@ public class CartController {
     public ResponseEntity<Cart> updateItemQuantity(@AuthenticationPrincipal UserDetails userDetails,
             @RequestParam(required = false) String guestId,
             @PathVariable Long itemId,
-            @RequestParam Integer cantidad) {
+            @RequestBody UpdateCartItemRequest request) {
+
+        Integer cantidad = request.getCantidad();
         Long userId = null;
         boolean newGuest = false;
         if (userDetails != null) {

--- a/libreria/src/main/java/com/api/libreria/controller/VentaController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/VentaController.java
@@ -3,6 +3,7 @@ package com.api.libreria.controller;
 import com.api.libreria.model.Venta;
 import com.api.libreria.repository.UserRepository;
 import com.api.libreria.repository.VentaRepository;
+import com.api.libreria.dto.CreateSaleRequest;
 import com.api.libreria.service.VentaService;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -34,6 +35,14 @@ public class VentaController {
                                           @RequestParam String metodoPago) {
         Long userId = getUserId(userDetails.getUsername());
         Venta venta = ventaService.crearVentaDesdeCarrito(userId, metodoPago);
+        return ResponseEntity.ok(venta);
+    }
+
+    @PostMapping
+    public ResponseEntity<Venta> crearVenta(@AuthenticationPrincipal UserDetails userDetails,
+                                            @RequestBody CreateSaleRequest request) {
+        Long userId = getUserId(userDetails.getUsername());
+        Venta venta = ventaService.crearVentaDesdeCarrito(userId, request.getPaymentMethod());
         return ResponseEntity.ok(venta);
     }
 

--- a/libreria/src/main/java/com/api/libreria/dto/AddToCartRequest.java
+++ b/libreria/src/main/java/com/api/libreria/dto/AddToCartRequest.java
@@ -1,0 +1,9 @@
+package com.api.libreria.dto;
+
+import lombok.Data;
+
+@Data
+public class AddToCartRequest {
+    private Long libroId;
+    private Integer cantidad;
+}

--- a/libreria/src/main/java/com/api/libreria/dto/CreateSaleItemRequest.java
+++ b/libreria/src/main/java/com/api/libreria/dto/CreateSaleItemRequest.java
@@ -1,0 +1,10 @@
+package com.api.libreria.dto;
+
+import lombok.Data;
+
+@Data
+public class CreateSaleItemRequest {
+    private Long libroId;
+    private Integer cantidad;
+    private Double precioUnitario;
+}

--- a/libreria/src/main/java/com/api/libreria/dto/CreateSaleRequest.java
+++ b/libreria/src/main/java/com/api/libreria/dto/CreateSaleRequest.java
@@ -1,0 +1,10 @@
+package com.api.libreria.dto;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class CreateSaleRequest {
+    private String paymentMethod;
+    private List<CreateSaleItemRequest> items;
+}

--- a/libreria/src/main/java/com/api/libreria/dto/LoginResponse.java
+++ b/libreria/src/main/java/com/api/libreria/dto/LoginResponse.java
@@ -1,5 +1,6 @@
 package com.api.libreria.dto;
 
+import com.api.libreria.model.User;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -7,4 +8,5 @@ import lombok.Data;
 @AllArgsConstructor
 public class LoginResponse {
     private String token;
+    private User usuario;
 }

--- a/libreria/src/main/java/com/api/libreria/dto/UpdateCartItemRequest.java
+++ b/libreria/src/main/java/com/api/libreria/dto/UpdateCartItemRequest.java
@@ -1,0 +1,8 @@
+package com.api.libreria.dto;
+
+import lombok.Data;
+
+@Data
+public class UpdateCartItemRequest {
+    private Integer cantidad;
+}


### PR DESCRIPTION
## Summary
- add DTOs for cart and sale operations
- include user object in login response
- adjust cart endpoints to accept JSON bodies
- add POST /api/ventas to checkout cart

## Testing
- `./mvnw -q test` *(fails: failed to fetch from repo)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ea250ac083259fbc2ba10cbab7ca