### PR TITLE
Add logout endpoint and auto logout logic

### DIFF
--- a/libreria/src/main/java/com/api/libreria/controller/AuthController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/AuthController.java
@@ -51,4 +51,9 @@ public class AuthController {
         User user = userRepository.findByEmail(request.getEmail()).orElseThrow();
         return ResponseEntity.ok(new LoginResponse(token, user));
     }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout() {
+        return ResponseEntity.ok("Logged out");
+    }
 }

--- a/libreria/src/main/java/com/api/libreria/security/JwtUtils.java
+++ b/libreria/src/main/java/com/api/libreria/security/JwtUtils.java
@@ -13,7 +13,7 @@ public class JwtUtils {
 
     // Clave secreta (BASE64)
     private final String jwtSecretBase64 = "yW3WxPuq1MKgAwrmspr9qCc4UDe7BQbqV0z1kGMiAb7aJxW6FTnyEnNRQpqrZLNEJVtd1lAvRaJMNzkKt3K0RQ==";
-    private final long jwtExpirationMs = 86400000; // 1 día
+    private final long jwtExpirationMs = 7200000; // 2 horas
 
     private SecretKey getSigningKey() {
         byte[] keyBytes = Decoders.BASE64.decode(jwtSecretBase64);

--- a/studio/src/context/auth-provider.tsx
+++ b/studio/src/context/auth-provider.tsx
@@ -49,6 +49,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setUser(null);
   };
 
+  useEffect(() => {
+    const handleLogout = () => logout();
+    window.addEventListener('logout', handleLogout);
+    return () => window.removeEventListener('logout', handleLogout);
+  }, []);
+
   const isAuthenticated = !!token;
 
   return (

--- a/studio/src/lib/auth-utils.ts
+++ b/studio/src/lib/auth-utils.ts
@@ -9,3 +9,9 @@ export const getAuthHeaders = (): Record<string, string> => {
 
   return headers;
 };
+
+export const dispatchLogoutEvent = (): void => {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event('logout'));
+  }
+};

--- a/studio/src/services/api.ts
+++ b/studio/src/services/api.ts
@@ -1,5 +1,5 @@
 
-import { getAuthHeaders } from '@/lib/auth-utils';
+import { getAuthHeaders, dispatchLogoutEvent } from '@/lib/auth-utils';
 import type { Book, Category, Editorial, User, Cart, Sale, Offer, CreateSalePayload, CreateOfferPayload, ApiResponseError } from '@/types'; // Ensure all necessary types are imported
 
 // Import mock functions
@@ -41,6 +41,10 @@ async function fetchApi<T>(endpoint: string, options: FetchApiOptions = {}): Pro
 
   try {
     const response = await fetch(url, config);
+
+    if (response.status === 401) {
+      dispatchLogoutEvent();
+    }
 
     if (!response.ok) {
       let errorData;


### PR DESCRIPTION
## Summary
- expire JWT tokens after two hours
- add `/api/auth/logout` endpoint
- dispatch a `logout` event on 401 responses and handle it in the React context

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing modules)*
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f32a03848325a55b47484e221058