### PR TITLE
Handle paginated categories response

### DIFF
--- a/studio/src/services/api.ts
+++ b/studio/src/services/api.ts
@@ -158,9 +158,18 @@ export const deleteBook = async (id: string | number): Promise<void> => {
 };
 
 // --- Categories ---
-export const getCategories = async (): Promise<Category[]> => {
+export const getCategories = async (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params: Record<string, any> = {},
+): Promise<Category[]> => {
   if (API_MODE === 'mock') return mockApi.mockGetCategories();
-  return fetchApi<Category[]>('/api/categorias');
+
+  const query = new URLSearchParams(params).toString();
+  const page: Page<Category> = await fetchApi<Page<Category>>(
+    `/api/categorias${query ? '?' + query : ''}`,
+  );
+
+  return page.content;
 };
 
 export const createCategory = async (categoryData: Partial<Category>): Promise<Category> => {


### PR DESCRIPTION
## Summary
- adapt `getCategories` service to parse paginated results

## Testing
- `npm install` *(fails: network restricted)*
- `npm run lint` *(not run due to failed install)*
- `./mvnw -q test` *(fails: could not fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6855f62c0e6c832587a31f8874b5232c