### PR TITLE
Fix BookListClient prop

### DIFF
--- a/studio/src/app/[lang]/admin/panel/books/page.tsx
+++ b/studio/src/app/[lang]/admin/panel/books/page.tsx
@@ -119,7 +119,7 @@ function ManageBooksContent({ params }: ManageBooksContentProps) {
     return <BookFormClient key={keyForForm} book={editingBook} onSave={handleSaveBook} onDelete={handleDeleteBook} lang={lang} />;
   }
 
-  return <BookListClient initialBooks={books} onDeleteBook={handleDeleteBook} lang={lang} />;
+  return <BookListClient books={books} onDeleteBook={handleDeleteBook} lang={lang} />;
 }
 
 interface ManageBooksPageProps {


### PR DESCRIPTION
## Summary
- ensure ManageBooksContent passes `books` prop to `BookListClient`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6855f77fc7608325bc21301a1d2233e2