### PR TITLE
Fix editorial list prop mismatch

### DIFF
--- a/studio/src/app/[lang]/admin/panel/editorials/components/manage-editorials-content.tsx
+++ b/studio/src/app/[lang]/admin/panel/editorials/components/manage-editorials-content.tsx
@@ -17,12 +17,12 @@ import { Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast'; // Added useToast
 
 interface ManageEditorialsContentProps {
-  params: { lang: string } | Promise<{ lang: string }>; // Changed lang to be a required string
-  initialEditorials: Editorial[];
+  params: { lang: string } | Promise<{ lang: string }>;
+  initialEditorials?: Editorial[];
   texts: any;
 }
 
-export function ManageEditorialsContent({ params, initialEditorials, texts }: ManageEditorialsContentProps) {
+export function ManageEditorialsContent({ params, initialEditorials = [], texts }: ManageEditorialsContentProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { toast } = useToast(); // Initialized useToast
@@ -143,10 +143,12 @@ export function ManageEditorialsContent({ params, initialEditorials, texts }: Ma
   }
 
   // Default to list view
-  return <EditorialListClient
-            initialEditorials={editorials} // Pass the current state of editorials
-            onDeleteEditorial={handleDeleteEditorial}
-            lang={lang}
-            texts={texts}
-          />;
+  return (
+    <EditorialListClient
+      editorials={editorials}
+      onDeleteEditorial={handleDeleteEditorial}
+      lang={lang}
+      texts={texts}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- fix `editorials` prop being undefined by defaulting `initialEditorials` to an empty array
- rename prop when rendering `EditorialListClient`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6855f7c22a3c83259f0540d8b4a65030