### PR TITLE
Fix Loader2 undefined error

### DIFF
--- a/studio/src/app/[lang]/admin/panel/stats/components/stats-client.tsx
+++ b/studio/src/app/[lang]/admin/panel/stats/components/stats-client.tsx
@@ -15,7 +15,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
-import { CalendarIcon, DollarSign, TrendingUp, ShoppingBag, Filter } from 'lucide-react';
+import { CalendarIcon, DollarSign, TrendingUp, ShoppingBag, Filter, Loader2 } from 'lucide-react';
 import { ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent, ChartStyle } from '@/components/ui/chart';
 import { Bar, BarChart, Line, LineChart, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend, PieChart, Pie, Cell } from 'recharts';
 import type { ChartConfig } from '@/components/ui/chart';


### PR DESCRIPTION
## Summary
- import `Loader2` in stats-client

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6855f875ebe88325a3525643a195b6b8