### PR TITLE
Add user profile menu with logout

### DIFF
--- a/studio/src/components/layout/header.tsx
+++ b/studio/src/components/layout/header.tsx
@@ -6,6 +6,8 @@ import { BookOpen, ShoppingCart, Settings } from 'lucide-react';
 import { CorreoLibroLogo } from '@/components/icons/logo';
 // import { useCart } from '@/hooks/use-cart'; // Temporarily commented out for diagnosis
 import { ThemeToggle } from '@/components/theme-toggle';
+import { UserMenu } from '@/components/user-menu';
+import { useAuth } from '@/context/auth-provider';
 import { Button } from '@/components/ui/button';
 import { LanguageSwitcher } from '@/components/language-switcher';
 import type { Dictionary } from '@/types';
@@ -20,6 +22,7 @@ export function Header({ lang, dictionary }: HeaderProps) {
   // const itemCount = getItemCount(); // Temporarily commented out
   const itemCount = 0; // Placeholder for diagnosis
   const isLoading = true; // Placeholder for diagnosis
+  const { isAuthenticated } = useAuth();
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -44,7 +47,11 @@ export function Header({ lang, dictionary }: HeaderProps) {
               )*/}
             </Button>
           </Link>
-          <ThemeToggle />
+          {isAuthenticated ? (
+            <UserMenu lang={lang} dictionary={dictionary} />
+          ) : (
+            <ThemeToggle />
+          )}
           <LanguageSwitcher dictionary={dictionary} />
           <Button asChild variant="ghost" size="icon">
             <Link href={`/${lang}/admin`} aria-label={dictionary.header.admin}>

--- a/studio/src/components/user-menu.tsx
+++ b/studio/src/components/user-menu.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+import { useAuth } from "@/context/auth-provider";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { Dictionary } from "@/types";
+
+interface UserMenuProps {
+  lang: string;
+  dictionary: Dictionary;
+}
+
+export function UserMenu({ lang, dictionary }: UserMenuProps) {
+  const { user, logout } = useAuth();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon" aria-label={dictionary.header.profile ?? "Profile"}>
+          <Avatar>
+            {user?.avatarUrl ? (
+              <AvatarImage src={user.avatarUrl} alt={user.nombre} />
+            ) : (
+              <AvatarFallback>{user?.nombre?.charAt(0) ?? "U"}</AvatarFallback>
+            )}
+          </Avatar>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem asChild>
+          <Link href={`/${lang}/profile`}>{dictionary.header.profile ?? "Profile"}</Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={logout}>
+          {dictionary.header.logout ?? "Logout"}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/studio/src/dictionaries/en.json
+++ b/studio/src/dictionaries/en.json
@@ -8,7 +8,9 @@
     "cart": "Cart",
     "admin": "Admin",
     "toggleTheme": "Toggle theme",
-    "changeLanguage": "Change language"
+    "changeLanguage": "Change language",
+    "profile": "Profile",
+    "logout": "Logout"
   },
   "footer": {
     "copyright": "© {year} Librería 33. All rights reserved."

--- a/studio/src/dictionaries/es.json
+++ b/studio/src/dictionaries/es.json
@@ -8,7 +8,9 @@
     "cart": "Carrito",
     "admin": "Admin",
     "toggleTheme": "Cambiar tema",
-    "changeLanguage": "Cambiar idioma"
+    "changeLanguage": "Cambiar idioma",
+    "profile": "Perfil",
+    "logout": "Cerrar sesión"
   },
   "footer": {
     "copyright": "© {year} Librería 33. Todos los derechos reservados."

--- a/studio/src/types/index.ts
+++ b/studio/src/types/index.ts
@@ -155,6 +155,8 @@ export type Dictionary = {
     admin: string;
     toggleTheme: string;
     changeLanguage: string;
+    profile?: string;
+    logout?: string;
   };
   footer: {
     copyright: string;


### PR DESCRIPTION
## Summary
- create **UserMenu** component using a dropdown avatar
- swap theme toggle for user menu when authenticated
- add profile and logout texts in both dictionaries
- extend dictionary types to include the new keys

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855f8c196288325bc6bc2e0c7e2a07e