### PR TITLE
Add persistent user menu

### DIFF
--- a/studio/src/app/[lang]/admin/panel/layout.tsx
+++ b/studio/src/app/[lang]/admin/panel/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeToggle } from '@/components/theme-toggle';
 import { Button, buttonVariants } from '@/components/ui/button'; 
 import { LayoutDashboard, BookCopy, Users, Home, Store, Receipt, Building2, Menu, Tags, BarChart3, FileSpreadsheet } from 'lucide-react';
 import { LanguageSwitcher } from '@/components/language-switcher';
+import { AuthUserMenu } from '@/components/auth-user-menu';
 import { getDictionary } from '@/lib/dictionaries';
 import type { Dictionary } from '@/types';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetClose, SheetTrigger } from '@/components/ui/sheet'; 
@@ -56,6 +57,7 @@ async function AdminPanelHeader({ lang, dictionary }: { lang: string, dictionary
           </Link>
           <ThemeToggle />
           <LanguageSwitcher dictionary={dictionary}/>
+          <AuthUserMenu lang={lang} dictionary={dictionary} />
         </div>
       </div>
     </header>

--- a/studio/src/components/auth-user-menu.tsx
+++ b/studio/src/components/auth-user-menu.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import type { Dictionary } from '@/types';
+import { useAuth } from '@/context/auth-provider';
+import { UserMenu } from '@/components/user-menu';
+
+interface AuthUserMenuProps {
+  lang: string;
+  dictionary: Dictionary;
+}
+
+export function AuthUserMenu({ lang, dictionary }: AuthUserMenuProps) {
+  const { isAuthenticated } = useAuth();
+  if (!isAuthenticated) return null;
+  return <UserMenu lang={lang} dictionary={dictionary} />;
+}

--- a/studio/src/components/layout/header.tsx
+++ b/studio/src/components/layout/header.tsx
@@ -51,14 +51,15 @@ export function Header({ lang, dictionary }: HeaderProps) {
             <ThemeToggle />
          
           <LanguageSwitcher dictionary={dictionary} />
-          <Button asChild variant="ghost" size="icon">
-            <Link href={`/${lang}/admin`} aria-label={dictionary.header.admin}>
-              <Settings className="h-5 w-5" />
-            </Link>
-          </Button>
           {isAuthenticated ? (
             <UserMenu lang={lang} dictionary={dictionary} />
-          ) : (null)}
+          ) : (
+            <Button asChild variant="ghost" size="icon">
+              <Link href={`/${lang}/admin`} aria-label={dictionary.header.admin}>
+                <Settings className="h-5 w-5" />
+              </Link>
+            </Button>
+          )}
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- create `AuthUserMenu` wrapper component
- swap admin link for `UserMenu` when authenticated
- show `AuthUserMenu` in admin panel header to keep menu visible

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68560440542c832596e38403eaf8f25d