### PR TITLE
Remove unused local placeholder image

### DIFF
--- a/studio/src/app/[lang]/admin/panel/books/components/book-list-client.tsx
+++ b/studio/src/app/[lang]/admin/panel/books/components/book-list-client.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect } from 'react';
 import Image from 'next/image';
+import { getCoverImageUrl } from '@/lib/utils';
 import Link from 'next/link';
 import type { Book } from '@/types';
 import { Button } from '@/components/ui/button';
@@ -102,11 +103,14 @@ export function BookListClient({ books, onDeleteBook, lang }: BookListClientProp
                 <TableRow key={book.id}>
                   <TableCell>
                     <Image
-                      src={book.coverImage ? `${process.env.NEXT_PUBLIC_API_BASE_URL || ''}${book.coverImage}` : '/placeholder-image.png'}
+                      src={getCoverImageUrl(book.coverImage)}
                       alt={book.titulo}
                       width={50}
                       height={75}
                       className="rounded object-cover"
+                      onError={(e) => {
+                        e.currentTarget.src = 'https://placehold.co/600x900?text=No+Image';
+                      }}
                     />
                   </TableCell>
                   <TableCell className="font-medium">{book.titulo}</TableCell>

--- a/studio/src/app/[lang]/admin/panel/pos/components/pos-client.tsx
+++ b/studio/src/app/[lang]/admin/panel/pos/components/pos-client.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect, useMemo } from 'react';
 import Image from 'next/image';
+import { getCoverImageUrl } from '@/lib/utils';
 import type { Book, Sale, CreateSalePayload, CreateSaleItemPayload, ApiResponseError } from '@/types'; // Use API Sale types
 import type { Dictionary } from '@/types'; 
 import { Button } from '@/components/ui/button';
@@ -170,7 +171,17 @@ export function PosClient({ lang, dictionary, allBooks, posTexts }: PosClientPro
                   {searchResults.map(book => (
                     <li key={book.id} className="flex items-center justify-between p-2 hover:bg-accent rounded-md">
                       <div className="flex items-center space-x-2 overflow-hidden">
-                        <Image src={book.coverImage ? `${process.env.NEXT_PUBLIC_API_BASE_URL || ''}${book.coverImage}` : '/placeholder-image.png'} alt={book.titulo} width={30} height={45} className="rounded object-cover" data-ai-hint="book cover search"/>
+                        <Image
+                          src={getCoverImageUrl(book.coverImage)}
+                          alt={book.titulo}
+                          width={30}
+                          height={45}
+                          className="rounded object-cover"
+                          onError={(e) => {
+                            e.currentTarget.src = 'https://placehold.co/600x900?text=No+Image';
+                          }}
+                          data-ai-hint="book cover search"
+                        />
                         <div className="flex-grow overflow-hidden">
                           <p className="text-sm font-medium truncate" title={book.titulo}>{book.titulo}</p> 
                           <p className="text-xs text-muted-foreground truncate" title={book.autor}>{book.autor}</p>
@@ -214,7 +225,17 @@ export function PosClient({ lang, dictionary, allBooks, posTexts }: PosClientPro
                     {currentOrderItems.map(item => (
                       <TableRow key={item.book.id}>
                         <TableCell className="flex items-center space-x-2">
-                        <Image src={item.book.coverImage ? `${process.env.NEXT_PUBLIC_API_BASE_URL || ''}${item.book.coverImage}` : '/placeholder-image.png'} alt={item.book.titulo} width={40} height={60} className="rounded object-cover" data-ai-hint="book cover order"/>
+                        <Image
+                          src={getCoverImageUrl(item.book.coverImage)}
+                          alt={item.book.titulo}
+                          width={40}
+                          height={60}
+                          className="rounded object-cover"
+                          onError={(e) => {
+                            e.currentTarget.src = 'https://placehold.co/600x900?text=No+Image';
+                          }}
+                          data-ai-hint="book cover order"
+                        />
                           <div>
                           <p className="font-medium truncate w-32" title={item.book.titulo}>{item.book.titulo}</p> 
                           <p className="text-xs text-muted-foreground truncate w-32" title={item.book.autor}>{item.book.autor}</p> 

--- a/studio/src/app/[lang]/books/[id]/page.tsx
+++ b/studio/src/app/[lang]/books/[id]/page.tsx
@@ -13,6 +13,7 @@ import { LightboxClient } from '@/app/books/[id]/components/lightbox-client';
 // Import the new client component
 import { AddToCartButton } from '@/app/books/[id]/components/add-to-cart-button';
 import Link from 'next/link'; // Import Link
+import { getCoverImageUrl } from '@/lib/utils';
 
 // Updated generateStaticParams to use the API
 export async function generateStaticParams() {
@@ -90,7 +91,7 @@ export default async function BookDetailPage({ params }: BookDetailPageProps) {
         <div className="grid md:grid-cols-2 gap-8 lg:gap-12 items-start">
           <div>
             <LightboxClient
-              src={book.coverImage ? `${process.env.NEXT_PUBLIC_API_BASE_URL || ''}${book.coverImage}` : 'https://placehold.co/600x900.png'}
+              src={getCoverImageUrl(book.coverImage, 'https://placehold.co/600x900.png')}
               alt={book.titulo || "Book cover"}
               width={600}
               height={900}

--- a/studio/src/app/[lang]/cart/components/cart-item-row-client.tsx
+++ b/studio/src/app/[lang]/cart/components/cart-item-row-client.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import Image from 'next/image';
+import { getCoverImageUrl } from '@/lib/utils';
 import Link from 'next/link';
 // Ensure CartItem is the one from '@/types' that matches API structure
 import type { CartItem as ApiCartItem, Dictionary } from '@/types'; 
@@ -65,11 +66,14 @@ export function CartItemRowClient({ item, lang, dictionary }: CartItemRowClientP
       <div className="flex items-center space-x-4 mb-4 sm:mb-0">
         <Link href={`/${lang}/books/${bookDetails.id}`}>
           <Image
-            src={bookDetails.coverImage ? `${process.env.NEXT_PUBLIC_API_BASE_URL || ''}${bookDetails.coverImage}` : '/placeholder-image.png'}
+            src={getCoverImageUrl(bookDetails.coverImage)}
             alt={bookDetails.titulo}
             width={80}
             height={120}
             className="rounded-md object-cover border"
+            onError={(e) => {
+              e.currentTarget.src = 'https://placehold.co/600x900?text=No+Image';
+            }}
           />
         </Link>
         <div>

--- a/studio/src/app/[lang]/catalog/components/book-card.tsx
+++ b/studio/src/app/[lang]/catalog/components/book-card.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import Image from 'next/image';
+import { getCoverImageUrl } from '@/lib/utils';
 import Link from 'next/link';
 import type { Book, Dictionary } from '@/types';
 import { Button } from '@/components/ui/button';
@@ -20,8 +21,7 @@ export function BookCard({ book, lang, dictionary }: BookCardProps) {
   const { addItem } = useCart();
   const { toast } = useToast();
 
-  const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || '';
-  const imageSrc = book.coverImage ? `${apiBase}${book.coverImage}` : 'https://placehold.co/300x450.png';
+  const imageSrc = getCoverImageUrl(book.coverImage, 'https://placehold.co/300x450.png');
 
   // Robust check for the book object itself and its id
   if (!book || typeof book !== 'object' || !book.id) {
@@ -60,6 +60,9 @@ export function BookCard({ book, lang, dictionary }: BookCardProps) {
             width={300}
             height={450}
             className="w-full h-72 object-cover"
+            onError={(e) => {
+              e.currentTarget.src = 'https://placehold.co/600x900?text=No+Image';
+            }}
             data-ai-hint="book cover"
           />
         </Link>

--- a/studio/src/app/admin/books/components/book-list-client.tsx
+++ b/studio/src/app/admin/books/components/book-list-client.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect } from 'react';
 import Image from 'next/image';
+import { getCoverImageUrl } from '@/lib/utils';
 import Link from 'next/link';
 import type { Book } from '@/types';
 import { Button } from '@/components/ui/button';
@@ -98,11 +99,14 @@ export function BookListClient({ initialBooks, onDeleteBook }: BookListClientPro
                 <TableRow key={book.id}>
                   <TableCell>
                     <Image
-                      src={book.coverImage ? `${process.env.NEXT_PUBLIC_API_BASE_URL || ''}${book.coverImage}` : '/placeholder-image.png'}
+                      src={getCoverImageUrl(book.coverImage)}
                       alt={book.title}
                       width={50}
                       height={75}
                       className="rounded object-cover"
+                      onError={(e) => {
+                        e.currentTarget.src = 'https://placehold.co/600x900?text=No+Image';
+                      }}
                       data-ai-hint="book cover admin"
                     />
                   </TableCell>

--- a/studio/src/app/books/[id]/page.tsx
+++ b/studio/src/app/books/[id]/page.tsx
@@ -10,6 +10,7 @@ import { LightboxClient } from './components/lightbox-client'; // This component
 import { CartProvider, useCart } from '@/context/cart-provider'; 
 import type { Book } from '@/types'; // Import Book type
 import Image from 'next/image'; // Import Image
+import { getCoverImageUrl } from '@/lib/utils';
 
 export async function generateStaticParams() {
   // This function would need to fetch actual book IDs from the API if this page were to be kept.
@@ -83,7 +84,7 @@ export default async function BookDetailPage({ params }: { params: { id: string 
           <div className="grid md:grid-cols-2 gap-8 lg:gap-12 items-start">
             <div>
               <LightboxClient
-                src={book.coverImage ? `${process.env.NEXT_PUBLIC_API_BASE_URL || ''}${book.coverImage}` : '/placeholder-image.png'}
+                src={getCoverImageUrl(book.coverImage)}
                 alt={book.titulo || 'Book cover'} // Use API field
                 width={600}
                 height={900}

--- a/studio/src/app/catalog/components/book-card.tsx
+++ b/studio/src/app/catalog/components/book-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from 'next/image';
+import { getCoverImageUrl } from '@/lib/utils';
 import Link from 'next/link';
 import type { Book } from '@/types';
 import { Button } from '@/components/ui/button';
@@ -17,8 +18,7 @@ export function BookCard({ book }: BookCardProps) {
   const { addToCart } = useCart();
   const { toast } = useToast();
 
-  const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || '';
-  const imageSrc = book.coverImage ? `${apiBase}${book.coverImage}` : 'https://placehold.co/300x450.png';
+  const imageSrc = getCoverImageUrl(book.coverImage, 'https://placehold.co/300x450.png');
 
   const handleAddToCart = () => {
     addToCart(book);
@@ -38,6 +38,9 @@ export function BookCard({ book }: BookCardProps) {
             width={300}
             height={450}
             className="w-full h-72 object-cover"
+            onError={(e) => {
+              e.currentTarget.src = 'https://placehold.co/600x900?text=No+Image';
+            }}
             data-ai-hint={`${book.genre} book cover`}
           />
         </Link>

--- a/studio/src/lib/utils.ts
+++ b/studio/src/lib/utils.ts
@@ -4,3 +4,22 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Build the correct image URL for book cover images.
+ * If the provided path is already absolute (starts with http:// or https://)
+ * it will be returned as is. Otherwise, it will be prefixed with the API base
+ * URL from `NEXT_PUBLIC_API_BASE_URL`.
+ * If no image is provided, a placeholder path is returned.
+ */
+export function getCoverImageUrl(
+  coverImage?: string | null,
+  placeholder = 'https://placehold.co/600x900?text=No+Image',
+): string {
+  if (!coverImage) return placeholder;
+  if (/^https?:\/\//i.test(coverImage)) {
+    return coverImage;
+  }
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL || '';
+  return `${base}${coverImage}`;
+}


### PR DESCRIPTION
## Summary
- drop local placeholder-image.png
- default to remote placeholder URL in `getCoverImageUrl`
- update image error handlers to use the new placeholder

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68560dbd14b88325980ec39836dd1b03