### PR TITLE
Handle expired JWT with 401 and logout redirect

### DIFF
--- a/libreria/src/main/java/com/api/libreria/security/JwtAuthenticationFilter.java
+++ b/libreria/src/main/java/com/api/libreria/security/JwtAuthenticationFilter.java
@@ -44,6 +44,11 @@ public class JwtAuthenticationFilter extends GenericFilter {
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+                chain.doFilter(request, response);
+                return;
+            } else {
+                ((HttpServletResponse) response).sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid or expired token");
+                return;
             }
         }
 

--- a/studio/src/context/auth-provider.tsx
+++ b/studio/src/context/auth-provider.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 interface AuthContextType {
   user: any | null;
@@ -13,6 +16,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<any | null>(null);
   const [token, setToken] = useState<string | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
   const storedToken = localStorage.getItem('authToken');
@@ -47,6 +51,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     document.cookie = 'authToken=; path=/; max-age=0';
     setToken(null);
     setUser(null);
+    router.push('/es');
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- send a 401 response when the JWT is invalid or expired
- mark `AuthProvider` as a client component and redirect to `/es` when logging out

## Testing
- `./mvnw -q test` *(fails: failed to fetch dependencies)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f2d65bb48325886e0f70723228f4