### PR TITLE
Improve image handling with fallback

### DIFF
--- a/studio/src/app/[lang]/admin/panel/books/components/book-list-client.tsx
+++ b/studio/src/app/[lang]/admin/panel/books/components/book-list-client.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useState, useEffect } from 'react';
-import Image from 'next/image';
+import { ImageWithFallback } from '@/components/image-with-fallback';
 import { getCoverImageUrl } from '@/lib/utils';
 import Link from 'next/link';
 import type { Book } from '@/types';
@@ -102,15 +102,12 @@ export function BookListClient({ books, onDeleteBook, lang }: BookListClientProp
               {filteredBooks.map((book) => (
                 <TableRow key={book.id}>
                   <TableCell>
-                    <Image
+                    <ImageWithFallback
                       src={getCoverImageUrl(book.coverImage)}
                       alt={book.titulo}
                       width={50}
                       height={75}
                       className="rounded object-cover"
-                      onError={(e) => {
-                        e.currentTarget.src = 'https://placehold.co/600x900?text=No+Image';
-                      }}
                     />
                   </TableCell>
                   <TableCell className="font-medium">{book.titulo}</TableCell>

--- a/studio/src/app/[lang]/admin/panel/pos/components/pos-client.tsx
+++ b/studio/src/app/[lang]/admin/panel/pos/components/pos-client.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from 'react';
-import Image from 'next/image';
+import { ImageWithFallback } from '@/components/image-with-fallback';
 import { getCoverImageUrl } from '@/lib/utils';
 import type { Book, Sale, CreateSalePayload, CreateSaleItemPayload, ApiResponseError } from '@/types'; // Use API Sale types
 import type { Dictionary } from '@/types'; 
@@ -171,15 +171,12 @@ export function PosClient({ lang, dictionary, allBooks, posTexts }: PosClientPro
                   {searchResults.map(book => (
                     <li key={book.id} className="flex items-center justify-between p-2 hover:bg-accent rounded-md">
                       <div className="flex items-center space-x-2 overflow-hidden">
-                        <Image
+                        <ImageWithFallback
                           src={getCoverImageUrl(book.coverImage)}
                           alt={book.titulo}
                           width={30}
                           height={45}
                           className="rounded object-cover"
-                          onError={(e) => {
-                            e.currentTarget.src = 'https://placehold.co/600x900?text=No+Image';
-                          }}
                           data-ai-hint="book cover search"
                         />
                         <div className="flex-grow overflow-hidden">
@@ -225,15 +222,12 @@ export function PosClient({ lang, dictionary, allBooks, posTexts }: PosClientPro
                     {currentOrderItems.map(item => (
                       <TableRow key={item.book.id}>
                         <TableCell className="flex items-center space-x-2">
-                        <Image
+                        <ImageWithFallback
                           src={getCoverImageUrl(item.book.coverImage)}
                           alt={item.book.titulo}
                           width={40}
                           height={60}
                           className="rounded object-cover"
-                          onError={(e) => {
-                            e.currentTarget.src = 'https://placehold.co/600x900?text=No+Image';
-                          }}
                           data-ai-hint="book cover order"
                         />
                           <div>

--- a/studio/src/app/[lang]/books/[id]/page.tsx
+++ b/studio/src/app/[lang]/books/[id]/page.tsx
@@ -91,7 +91,7 @@ export default async function BookDetailPage({ params }: BookDetailPageProps) {
         <div className="grid md:grid-cols-2 gap-8 lg:gap-12 items-start">
           <div>
             <LightboxClient
-              src={getCoverImageUrl(book.coverImage, 'https://placehold.co/600x900.png')}
+              src={getCoverImageUrl(book.coverImage, 'https://placehold.co/600x900.png?text=Sin+imagen')}
               alt={book.titulo || "Book cover"}
               width={600}
               height={900}

--- a/studio/src/app/[lang]/cart/components/cart-item-row-client.tsx
+++ b/studio/src/app/[lang]/cart/components/cart-item-row-client.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import Image from 'next/image';
+import { ImageWithFallback } from '@/components/image-with-fallback';
 import { getCoverImageUrl } from '@/lib/utils';
 import Link from 'next/link';
 // Ensure CartItem is the one from '@/types' that matches API structure
@@ -65,15 +65,12 @@ export function CartItemRowClient({ item, lang, dictionary }: CartItemRowClientP
     <div className="flex flex-col sm:flex-row items-center justify-between py-4">
       <div className="flex items-center space-x-4 mb-4 sm:mb-0">
         <Link href={`/${lang}/books/${bookDetails.id}`}>
-          <Image
+          <ImageWithFallback
             src={getCoverImageUrl(bookDetails.coverImage)}
             alt={bookDetails.titulo}
             width={80}
             height={120}
             className="rounded-md object-cover border"
-            onError={(e) => {
-              e.currentTarget.src = 'https://placehold.co/600x900?text=No+Image';
-            }}
           />
         </Link>
         <div>

--- a/studio/src/app/[lang]/catalog/components/book-card.tsx
+++ b/studio/src/app/[lang]/catalog/components/book-card.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import Image from 'next/image';
+import { ImageWithFallback } from '@/components/image-with-fallback';
 import { getCoverImageUrl } from '@/lib/utils';
 import Link from 'next/link';
 import type { Book, Dictionary } from '@/types';
@@ -21,7 +21,7 @@ export function BookCard({ book, lang, dictionary }: BookCardProps) {
   const { addItem } = useCart();
   const { toast } = useToast();
 
-  const imageSrc = getCoverImageUrl(book.coverImage, 'https://placehold.co/300x450.png');
+  const imageSrc = getCoverImageUrl(book.coverImage, 'https://placehold.co/300x450.png?text=Sin+imagen');
 
   // Robust check for the book object itself and its id
   if (!book || typeof book !== 'object' || !book.id) {
@@ -54,15 +54,12 @@ export function BookCard({ book, lang, dictionary }: BookCardProps) {
     <Card className="flex flex-col overflow-hidden h-full shadow-md hover:shadow-lg transition-shadow duration-300 rounded-lg">
       <CardHeader className="p-0">
         <Link href={`/${lang}/books/${book.id}`} className="block">
-          <Image
+          <ImageWithFallback
             src={imageSrc}
             alt={bookTitle}
             width={300}
             height={450}
             className="w-full h-72 object-cover"
-            onError={(e) => {
-              e.currentTarget.src = 'https://placehold.co/600x900?text=No+Image';
-            }}
             data-ai-hint="book cover"
           />
         </Link>

--- a/studio/src/app/admin/books/components/book-list-client.tsx
+++ b/studio/src/app/admin/books/components/book-list-client.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useState, useEffect } from 'react';
-import Image from 'next/image';
+import { ImageWithFallback } from '@/components/image-with-fallback';
 import { getCoverImageUrl } from '@/lib/utils';
 import Link from 'next/link';
 import type { Book } from '@/types';
@@ -98,15 +98,12 @@ export function BookListClient({ initialBooks, onDeleteBook }: BookListClientPro
               {filteredBooks.map((book) => (
                 <TableRow key={book.id}>
                   <TableCell>
-                    <Image
+                    <ImageWithFallback
                       src={getCoverImageUrl(book.coverImage)}
                       alt={book.title}
                       width={50}
                       height={75}
                       className="rounded object-cover"
-                      onError={(e) => {
-                        e.currentTarget.src = 'https://placehold.co/600x900?text=No+Image';
-                      }}
                       data-ai-hint="book cover admin"
                     />
                   </TableCell>

--- a/studio/src/app/books/[id]/components/lightbox-client.tsx
+++ b/studio/src/app/books/[id]/components/lightbox-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from 'react';
-import Image from 'next/image';
+import { ImageWithFallback } from '@/components/image-with-fallback';
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
 import { X } from 'lucide-react';
 
@@ -20,22 +20,22 @@ export function LightboxClient({ src, alt, width, height, triggerClassName }: Li
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
         <div className={`cursor-zoom-in relative overflow-hidden rounded-lg shadow-md hover:shadow-xl transition-shadow ${triggerClassName}`}>
-          <Image
+          <ImageWithFallback
             src={src}
             alt={alt}
             width={width}
             height={height}
             className="w-full h-auto object-contain"
-            priority 
+            priority
           />
         </div>
       </DialogTrigger>
       <DialogContent className="max-w-3xl p-2 bg-transparent border-none shadow-none !rounded-none">
         <div className="relative">
-           <Image
+           <ImageWithFallback
             src={src}
             alt={alt}
-            width={1200} 
+            width={1200}
             height={1800}
             className="w-full h-auto max-h-[90vh] object-contain rounded-md"
           />

--- a/studio/src/app/books/[id]/page.tsx
+++ b/studio/src/app/books/[id]/page.tsx
@@ -9,7 +9,7 @@ import { ShoppingCart } from 'lucide-react';
 import { LightboxClient } from './components/lightbox-client'; // This component might not exist or might need /lang/ prefix
 import { CartProvider, useCart } from '@/context/cart-provider'; 
 import type { Book } from '@/types'; // Import Book type
-import Image from 'next/image'; // Import Image
+import { ImageWithFallback } from '@/components/image-with-fallback';
 import { getCoverImageUrl } from '@/lib/utils';
 
 export async function generateStaticParams() {

--- a/studio/src/app/cart/components/cart-item-row-client.tsx
+++ b/studio/src/app/cart/components/cart-item-row-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from 'next/image';
+import { ImageWithFallback } from '@/components/image-with-fallback';
 import Link from 'next/link';
 import type { CartItem } from '@/types';
 import { useCart } from '@/hooks/use-cart';
@@ -23,7 +23,7 @@ export function CartItemRowClient({ item }: CartItemRowClientProps) {
     <div className="flex flex-col sm:flex-row items-center justify-between py-4 border-b last:border-b-0">
       <div className="flex items-center space-x-4 mb-4 sm:mb-0">
         <Link href={`/books/${item.book.id}`}>
-          <Image
+          <ImageWithFallback
             src={item.book.coverImage}
             alt={item.book.title}
             width={80}

--- a/studio/src/app/catalog/components/book-card.tsx
+++ b/studio/src/app/catalog/components/book-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from 'next/image';
+import { ImageWithFallback } from '@/components/image-with-fallback';
 import { getCoverImageUrl } from '@/lib/utils';
 import Link from 'next/link';
 import type { Book } from '@/types';
@@ -18,7 +18,7 @@ export function BookCard({ book }: BookCardProps) {
   const { addToCart } = useCart();
   const { toast } = useToast();
 
-  const imageSrc = getCoverImageUrl(book.coverImage, 'https://placehold.co/300x450.png');
+  const imageSrc = getCoverImageUrl(book.coverImage, 'https://placehold.co/300x450.png?text=Sin+imagen');
 
   const handleAddToCart = () => {
     addToCart(book);
@@ -32,15 +32,12 @@ export function BookCard({ book }: BookCardProps) {
     <Card className="flex flex-col overflow-hidden h-full shadow-md hover:shadow-lg transition-shadow duration-300 rounded-lg">
       <CardHeader className="p-0">
         <Link href={`/books/${book.id}`} className="block">
-          <Image
+          <ImageWithFallback
             src={imageSrc}
             alt={book.title}
             width={300}
             height={450}
             className="w-full h-72 object-cover"
-            onError={(e) => {
-              e.currentTarget.src = 'https://placehold.co/600x900?text=No+Image';
-            }}
             data-ai-hint={`${book.genre} book cover`}
           />
         </Link>

--- a/studio/src/components/image-with-fallback.tsx
+++ b/studio/src/components/image-with-fallback.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Image, { ImageProps } from 'next/image';
+import { useState, useEffect } from 'react';
+
+interface ImageWithFallbackProps extends ImageProps {
+  fallbackSrc?: ImageProps['src'];
+}
+
+export function ImageWithFallback({
+  src,
+  fallbackSrc = 'https://placehold.co/600x900?text=Sin+imagen',
+  ...props
+}: ImageWithFallbackProps) {
+  const [imgSrc, setImgSrc] = useState<ImageProps['src']>(src);
+
+  useEffect(() => {
+    setImgSrc(src);
+  }, [src]);
+
+  return (
+    <Image
+      {...props}
+      src={imgSrc}
+      onError={() => setImgSrc(fallbackSrc)}
+    />
+  );
+}
+

--- a/studio/src/lib/utils.ts
+++ b/studio/src/lib/utils.ts
@@ -14,7 +14,7 @@ export function cn(...inputs: ClassValue[]) {
  */
 export function getCoverImageUrl(
   coverImage?: string | null,
-  placeholder = 'https://placehold.co/600x900?text=No+Image',
+  placeholder = 'https://placehold.co/600x900?text=Sin+imagen',
 ): string {
   if (!coverImage) return placeholder;
   if (/^https?:\/\//i.test(coverImage)) {


### PR DESCRIPTION
## Summary
- add `ImageWithFallback` component for persistent fallback behavior
- use fallback component in book listings and details
- default placeholder text is now "Sin imagen"

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6856fe3540f483259dc386864f0c34ea