### PR TITLE
Update sale creation to use client cart

### DIFF
--- a/libreria/src/main/java/com/api/libreria/controller/VentaController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/VentaController.java
@@ -32,9 +32,9 @@ public class VentaController {
 
     @PostMapping("/checkout")
     public ResponseEntity<Venta> checkout(@AuthenticationPrincipal UserDetails userDetails,
-                                          @RequestParam String metodoPago) {
+                                          @RequestBody CreateSaleRequest request) {
         Long userId = getUserId(userDetails.getUsername());
-        Venta venta = ventaService.crearVentaDesdeCarrito(userId, metodoPago);
+        Venta venta = ventaService.crearVentaDesdeItems(userId, request.getPaymentMethod(), request.getItems());
         return ResponseEntity.ok(venta);
     }
 
@@ -42,7 +42,7 @@ public class VentaController {
     public ResponseEntity<Venta> crearVenta(@AuthenticationPrincipal UserDetails userDetails,
                                             @RequestBody CreateSaleRequest request) {
         Long userId = getUserId(userDetails.getUsername());
-        Venta venta = ventaService.crearVentaDesdeCarrito(userId, request.getPaymentMethod());
+        Venta venta = ventaService.crearVentaDesdeItems(userId, request.getPaymentMethod(), request.getItems());
         return ResponseEntity.ok(venta);
     }
 


### PR DESCRIPTION
## Summary
- adjust checkout endpoints to accept cart items from the request
- add `crearVentaDesdeItems` method to create sales without DB cart

## Testing
- `mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6877ab9fb6088325841426cb4be19da7