### PR TITLE
Prevent infinite JSON recursion in sales API

### DIFF
--- a/libreria/src/main/java/com/api/libreria/model/Venta.java
+++ b/libreria/src/main/java/com/api/libreria/model/Venta.java
@@ -2,6 +2,7 @@ package com.api.libreria.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,5 +28,6 @@ public class Venta {
     private String metodoPago;
 
     @OneToMany(mappedBy = "venta", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
     private List<VentaItem> items;
 }

--- a/libreria/src/main/java/com/api/libreria/model/VentaItem.java
+++ b/libreria/src/main/java/com/api/libreria/model/VentaItem.java
@@ -2,6 +2,7 @@ package com.api.libreria.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 
 @Entity
 @Table(name = "venta_items")
@@ -17,6 +18,7 @@ public class VentaItem {
 
     @ManyToOne
     @JoinColumn(name = "venta_id")
+    @JsonBackReference
     private Venta venta;
 
     @ManyToOne


### PR DESCRIPTION
## Summary
- prevent recursion between `Venta` and `VentaItem` models
- add Jackson annotations to manage parent/child relationship

## Testing
- `./mvnw -q test` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877b5966084832584fed50b348647a2