### PR TITLE
Implement sales ticket numbering

### DIFF
--- a/libreria/src/main/java/com/api/libreria/controller/VentaController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/VentaController.java
@@ -30,11 +30,17 @@ public class VentaController {
         this.userRepository = userRepository;
     }
 
+    @GetMapping("/next-ticket")
+    public ResponseEntity<?> getNextTicket() {
+        Integer next = ventaService.getNextTicket();
+        return ResponseEntity.ok(java.util.Collections.singletonMap("nextTicket", next));
+    }
+
     @PostMapping("/checkout")
     public ResponseEntity<Venta> checkout(@AuthenticationPrincipal UserDetails userDetails,
                                           @RequestBody CreateSaleRequest request) {
         Long userId = getUserId(userDetails.getUsername());
-        Venta venta = ventaService.crearVentaDesdeItems(userId, request.getPaymentMethod(), request.getItems());
+        Venta venta = ventaService.crearVentaDesdeItems(userId, request.getPaymentMethod(), request.getNumeroTicket(), request.getItems());
         return ResponseEntity.ok(venta);
     }
 
@@ -42,7 +48,7 @@ public class VentaController {
     public ResponseEntity<Venta> crearVenta(@AuthenticationPrincipal UserDetails userDetails,
                                             @RequestBody CreateSaleRequest request) {
         Long userId = getUserId(userDetails.getUsername());
-        Venta venta = ventaService.crearVentaDesdeItems(userId, request.getPaymentMethod(), request.getItems());
+        Venta venta = ventaService.crearVentaDesdeItems(userId, request.getPaymentMethod(), request.getNumeroTicket(), request.getItems());
         return ResponseEntity.ok(venta);
     }
 

--- a/libreria/src/main/java/com/api/libreria/dto/CreateSaleRequest.java
+++ b/libreria/src/main/java/com/api/libreria/dto/CreateSaleRequest.java
@@ -5,6 +5,7 @@ import lombok.Data;
 
 @Data
 public class CreateSaleRequest {
+    private Integer numeroTicket;
     private String paymentMethod;
     private List<CreateSaleItemRequest> items;
 }

--- a/libreria/src/main/java/com/api/libreria/model/Venta.java
+++ b/libreria/src/main/java/com/api/libreria/model/Venta.java
@@ -19,6 +19,9 @@ public class Venta {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "numero_ticket", nullable = false, unique = true)
+    private Integer numeroTicket;
+
     private Long usuarioId;
 
     private LocalDateTime fecha;

--- a/libreria/src/main/java/com/api/libreria/repository/VentaRepository.java
+++ b/libreria/src/main/java/com/api/libreria/repository/VentaRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface VentaRepository extends JpaRepository<Venta, Long> {
 
     Page<Venta> findByUsuarioId(Long usuarioId, Pageable pageable);
+
+    Venta findTopByOrderByNumeroTicketDesc();
 }

--- a/libreria/src/main/java/com/api/libreria/service/VentaService.java
+++ b/libreria/src/main/java/com/api/libreria/service/VentaService.java
@@ -31,7 +31,13 @@ public class VentaService  {
     }
 
     @Transactional
-    public Venta crearVentaDesdeCarrito(Long userId, String metodoPago) {
+    public synchronized Integer getNextTicket() {
+        Venta last = ventaRepository.findTopByOrderByNumeroTicketDesc();
+        return last == null ? 1 : last.getNumeroTicket() + 1;
+    }
+
+    @Transactional
+    public Venta crearVentaDesdeCarrito(Long userId, String metodoPago, Integer numeroTicket) {
         Cart cart = cartRepository.findByUsuarioId(userId)
                 .orElseThrow(() -> new RuntimeException("Carrito no encontrado"));
 
@@ -55,6 +61,7 @@ public class VentaService  {
 
         Venta venta = new Venta();
         venta.setUsuarioId(userId);
+        venta.setNumeroTicket(numeroTicket);
         venta.setFecha(LocalDateTime.now());
         venta.setMetodoPago(metodoPago);
         venta.setTotal(0.0);
@@ -84,7 +91,7 @@ public class VentaService  {
     }
 
     @Transactional
-    public Venta crearVentaDesdeItems(Long userId, String metodoPago, List<CreateSaleItemRequest> items) {
+    public Venta crearVentaDesdeItems(Long userId, String metodoPago, Integer numeroTicket, List<CreateSaleItemRequest> items) {
         if (items == null || items.isEmpty()) {
             throw new RuntimeException("El carrito est\u00e1 vac\u00edo");
         }
@@ -102,6 +109,7 @@ public class VentaService  {
 
         Venta venta = new Venta();
         venta.setUsuarioId(userId);
+        venta.setNumeroTicket(numeroTicket);
         venta.setFecha(LocalDateTime.now());
         venta.setMetodoPago(metodoPago);
         venta = ventaRepository.save(venta);

--- a/studio/src/app/[lang]/admin/panel/pos/components/pos-client.tsx
+++ b/studio/src/app/[lang]/admin/panel/pos/components/pos-client.tsx
@@ -16,7 +16,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { useToast } from '@/hooks/use-toast';
 import { Search, XCircle, PlusCircle, MinusCircle, ShoppingCart, DollarSign, CreditCard, Loader2 } from 'lucide-react';
 // Import createSale from API services
-import { createSale } from '@/services/api'; 
+import { createSale, getNextTicket } from '@/services/api';
 import { SaleTicketDialog } from './sale-ticket-dialog'; 
 
 interface PosClientProps {
@@ -110,12 +110,15 @@ export function PosClient({ lang, dictionary, allBooks, posTexts }: PosClientPro
     const saleItemsPayload: CreateSaleItemPayload[] = currentOrderItems.map(item => ({
       libroId: item.book.id,
       cantidad: item.quantity,
-      precioUnitario: item.book.precio, 
+      precioUnitario: item.book.precio,
     }));
+
+    const nextTicketResp = await getNextTicket();
 
     const salePayload: CreateSalePayload = {
       items: saleItemsPayload,
       paymentMethod: paymentMethod,
+      numeroTicket: nextTicketResp.nextTicket,
       // customerName: customerName || undefined, // If API supports it
     };
 
@@ -125,7 +128,7 @@ export function PosClient({ lang, dictionary, allBooks, posTexts }: PosClientPro
       setIsTicketDialogOpen(true); 
       toast({
         title: posTexts.saleCompletedToastTitle,
-        description: posTexts.saleCompletedToastDesc + (createdSale.id ? ` ID: ${createdSale.id}` : ""),
+        description: posTexts.saleCompletedToastDesc + ` Ticket: ${createdSale.numeroTicket}`,
       });
     } catch (error) {
       const apiError = error as ApiResponseError;

--- a/studio/src/app/[lang]/admin/panel/pos/components/sale-ticket-dialog.tsx
+++ b/studio/src/app/[lang]/admin/panel/pos/components/sale-ticket-dialog.tsx
@@ -26,7 +26,7 @@ interface SaleTicketDialogProps {
 }
 
 export function SaleTicketDialog({ isOpen, onClose, saleRecord, dictionary }: SaleTicketDialogProps) {
-  if (!saleRecord) return null;
+  if (!saleRecord || !saleRecord.items || saleRecord.items.length === 0) return null;
 
   const texts = dictionary.adminPanel?.posPage?.ticketDialog || { 
     title: "Sale Receipt",
@@ -49,7 +49,7 @@ export function SaleTicketDialog({ isOpen, onClose, saleRecord, dictionary }: Sa
 
 
   const handlePrint = () => {
-    console.log("Simulating print for sale ID:", saleRecord.id);
+    console.log("Simulating print for ticket:", saleRecord.numeroTicket);
   };
 
   return (
@@ -58,7 +58,7 @@ export function SaleTicketDialog({ isOpen, onClose, saleRecord, dictionary }: Sa
         <AlertDialogHeader>
           <AlertDialogTitle className="font-headline text-2xl text-primary">{texts.title}</AlertDialogTitle>
           <AlertDialogDescription>
-            {texts.saleId} <span className="font-mono text-xs">{saleRecord.id}</span><br/>
+            {texts.saleId} <span className="font-mono text-xs">{saleRecord.numeroTicket}</span><br/>
             {texts.date} {new Date(saleRecord.fecha).toLocaleString(dictionary.locale)}<br/>
             {texts.customer} {saleRecord.usuarioId ?? texts.notApplicableShort}
           </AlertDialogDescription>

--- a/studio/src/app/[lang]/checkout/components/checkout-form-client.tsx
+++ b/studio/src/app/[lang]/checkout/components/checkout-form-client.tsx
@@ -7,7 +7,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useCart } from '@/hooks/use-cart';
 import { useAuth } from '@/context/auth-provider'; // Import useAuth
-import { createSale } from '@/services/api'; // Import createSale
+import { createSale, getNextTicket } from '@/services/api'; // Import createSale
 import type { CreateSalePayload, CreateSaleItemPayload, ApiResponseError } from '@/types'; // Import necessary types
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -129,9 +129,12 @@ export function CheckoutFormClient({ lang, dictionary }: CheckoutFormClientProps
         precioUnitario: item.precioUnitario,
       }));
 
+      const next = await getNextTicket();
+
       const salePayload: CreateSalePayload = {
         items: saleItems,
         paymentMethod: data.paymentMethod, // From form
+        numeroTicket: next.nextTicket,
         // Add other fields from 'data' if needed by your backend for CreateSalePayload
         // e.g. customerName: data.name, shippingAddress: `${data.address}, ${data.city}, ${data.state} ${data.zip}`
         // For now, keeping it simple as per defined CreateSalePayload
@@ -141,7 +144,7 @@ export function CheckoutFormClient({ lang, dictionary }: CheckoutFormClientProps
       
       toast({
         title: texts.orderSubmittedToast,
-        description: `${texts.orderSubmittedToastDesc} Order ID: ${createdSale.id}`,
+        description: `${texts.orderSubmittedToastDesc} Ticket: ${createdSale.numeroTicket}`,
       });
       
       await clearCartContextAction(); // Clear cart from context/API

--- a/studio/src/app/[lang]/sales/history/page.tsx
+++ b/studio/src/app/[lang]/sales/history/page.tsx
@@ -48,6 +48,7 @@ export default function SalesHistoryPage({ params }: SalesHistoryPageProps) {
   const { lang } = params;
   const { isAuthenticated, user, token } = useAuth();
   const [sales, setSales] = useState<Sale[]>([]);
+  const [page, setPage] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [dictionary, setDictionary] = useState<Dictionary>(mockDictionary); // Use mock initially
@@ -80,7 +81,7 @@ export default function SalesHistoryPage({ params }: SalesHistoryPageProps) {
       setIsLoading(true);
       setError(null);
       try {
-        const userSales = await getUserSales();
+        const userSales = await getUserSales(page, 10);
         setSales(userSales);
       } catch (err) {
         const apiError = err as ApiResponseError;
@@ -92,7 +93,7 @@ export default function SalesHistoryPage({ params }: SalesHistoryPageProps) {
     };
 
     fetchSales();
-  }, [isAuthenticated, token, texts.error]); // Depend on token to re-fetch if user logs in/out
+  }, [isAuthenticated, token, texts.error, page]); // Depend on page and token
 
   if (!isAuthenticated) {
     return (
@@ -157,7 +158,7 @@ export default function SalesHistoryPage({ params }: SalesHistoryPageProps) {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>{texts.orderId}</TableHead>
+                    <TableHead>N.º Ticket</TableHead>
                     <TableHead>{texts.date}</TableHead>
                     <TableHead className="text-right">{texts.total}</TableHead>
                     <TableHead className="text-center">{texts.items}</TableHead>
@@ -167,7 +168,7 @@ export default function SalesHistoryPage({ params }: SalesHistoryPageProps) {
                 <TableBody>
                   {sales.map((sale) => (
                     <TableRow key={sale.id}>
-                      <TableCell className="font-medium">#{typeof sale.id === 'number' ? sale.id : String(sale.id).substring(0,8)}</TableCell>
+                      <TableCell className="font-medium">{sale.numeroTicket}</TableCell>
                       <TableCell>{new Date(sale.fecha).toLocaleDateString(lang, { year: 'numeric', month: 'long', day: 'numeric' })}</TableCell>
                       <TableCell className="text-right">UYU {sale.total.toFixed(2)}</TableCell>
                       <TableCell className="text-center">{sale.items.length}</TableCell>
@@ -184,6 +185,10 @@ export default function SalesHistoryPage({ params }: SalesHistoryPageProps) {
                 </TableBody>
               </Table>
             )}
+            <div className="flex justify-between mt-4">
+              <Button variant="outline" onClick={() => setPage(p => Math.max(0, p - 1))} disabled={page === 0}>Anterior</Button>
+              <Button variant="outline" onClick={() => setPage(p => p + 1)}>Siguiente</Button>
+            </div>
           </CardContent>
         </Card>
       </div>

--- a/studio/src/lib/mock-data.ts
+++ b/studio/src/lib/mock-data.ts
@@ -228,6 +228,7 @@ export const mockCreateSale = async (saleData: CreateSalePayload): Promise<Sale>
 
   const newSale: Sale = {
     id: generateId(),
+    numeroTicket: saleData.numeroTicket,
     usuarioId: mockLoggedInUser.id,
     fecha: new Date().toISOString(),
     total: totalAmount,
@@ -237,6 +238,12 @@ export const mockCreateSale = async (saleData: CreateSalePayload): Promise<Sale>
   mockSalesStore.unshift(newSale);
   mockCartStore = null; // Clear cart after sale
   return simulateApiDelay(newSale);
+};
+
+export const mockGetNextTicket = async (): Promise<{ nextTicket: number }> => {
+  const last = mockSalesStore[0];
+  const nextTicket = last ? (last.numeroTicket + 1) : 1;
+  return simulateApiDelay({ nextTicket });
 };
 
 export const mockGetUserSales = async (): Promise<Sale[]> => {

--- a/studio/src/services/api.ts
+++ b/studio/src/services/api.ts
@@ -271,9 +271,15 @@ export const createSale = async (saleData: CreateSalePayload): Promise<Sale> => 
   });
 };
 
-export const getUserSales = async (): Promise<Sale[]> => {
+export const getNextTicket = async (): Promise<{ nextTicket: number }> => {
+  if (API_MODE === 'mock') return mockApi.mockGetNextTicket();
+  return fetchApi<{ nextTicket: number }>('/api/ventas/next-ticket');
+};
+
+export const getUserSales = async (page = 0, size = 10): Promise<Sale[]> => {
   if (API_MODE === 'mock') return mockApi.mockGetUserSales();
-  return fetchApi<Sale[]>('/api/ventas');
+  const params = new URLSearchParams({ page: String(page), size: String(size) });
+  return fetchApi<Sale[]>(`/api/ventas?${params.toString()}`);
 };
 
 // getSaleById is missing from mock, adding simple one below

--- a/studio/src/types/index.ts
+++ b/studio/src/types/index.ts
@@ -78,6 +78,7 @@ export interface SaleItem {
 
 export interface Sale {
   id: number | string;
+  numeroTicket: number;
   usuarioId?: number | string; // Can be null if it's a guest sale or POS
   fecha: string; // ISO date string typically
   total: number;
@@ -97,6 +98,7 @@ export interface CreateSaleItemPayload {
 export interface CreateSalePayload {
   items: CreateSaleItemPayload[];
   paymentMethod: string; // e.g., 'credit_card', 'paypal', 'cash_on_delivery'
+  numeroTicket: number;
   // Optional: Add other fields the backend might expect for sale creation
   // paymentConfirmationToken?: string; // If payment is processed externally first
   // shippingAddressId?: string | number;


### PR DESCRIPTION
## Summary
- add `numeroTicket` to `Venta` entity and repository
- expose `/api/ventas/next-ticket`
- include ticket number in sale creation logic
- update frontend types and API utilities
- show ticket numbers in POS and sales history

## Testing
- `npm run typecheck` *(fails: Cannot find modules)*
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d552c54c8325add237844753aec4