### PR TITLE
Add invoice endpoint for sales

### DIFF
--- a/libreria/src/main/java/com/api/libreria/controller/VentaController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/VentaController.java
@@ -73,6 +73,14 @@ public class VentaController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @GetMapping(value = "/admin/{id}/invoice", produces = "text/html")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<String> getVentaAdminInvoice(@PathVariable Long id) {
+        return ventaService.getVentaWithItemsById(id)
+                .map(v -> ResponseEntity.ok(ventaService.generateInvoiceHtml(v)))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
     private Long getUserId(String nombre) {
         // Auth stores the username value, so search by username instead of email
         return userRepository.findByUsername(nombre).orElseThrow().getId();


### PR DESCRIPTION
## Summary
- enable VentaService to build an HTML invoice
- expose new endpoint `/admin/{id}/invoice` to deliver invoice HTML

## Testing
- `mvn test` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877df07be6c832592e72af7ca7e4f29