### PR TITLE
Add admin invoice viewer

### DIFF
--- a/studio/src/app/[lang]/admin/panel/sales/components/sale-detail-client.tsx
+++ b/studio/src/app/[lang]/admin/panel/sales/components/sale-detail-client.tsx
@@ -4,10 +4,10 @@ import type { Sale, SaleItem, Book, Dictionary } from '@/types';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { ArrowLeft, ShoppingBag } from 'lucide-react';
+import { ArrowLeft, ShoppingBag, Printer } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
-import { getBookById } from '@/services/api'; // To fetch book details if not included
+import { getBookById, getAdminSaleInvoice } from '@/services/api'; // To fetch book details if not included
 
 interface SaleDetailClientProps {
   sale: Sale;
@@ -22,6 +22,20 @@ interface EnrichedSaleItem extends SaleItem {
 export function SaleDetailClient({ sale, texts, lang }: SaleDetailClientProps) {
   const [enrichedItems, setEnrichedItems] = useState<EnrichedSaleItem[]>(sale.items);
   const [isLoadingItems, setIsLoadingItems] = useState(false);
+
+  const handleViewInvoice = async () => {
+    try {
+      const html = await getAdminSaleInvoice(sale.id);
+      const w = window.open('', '_blank');
+      if (w) {
+        w.document.open();
+        w.document.write(html);
+        w.document.close();
+      }
+    } catch (err) {
+      console.error('Failed to load invoice', err);
+    }
+  };
 
   useEffect(() => {
     const fetchBookDetailsForItems = async () => {
@@ -147,12 +161,15 @@ export function SaleDetailClient({ sale, texts, lang }: SaleDetailClientProps) {
           )}
         </div>
       </CardContent>
-      <CardFooter className="flex justify-end">
-         <Button variant="outline" asChild>
-            <Link href={`/${lang}/admin/panel/sales`}>
-              <ArrowLeft className="mr-2 h-4 w-4" /> {texts.backToList || "Back to List"}
-            </Link>
-          </Button>
+      <CardFooter className="flex justify-end space-x-2">
+        <Button variant="outline" onClick={handleViewInvoice}>
+          <Printer className="mr-2 h-4 w-4" /> {texts.viewInvoiceButton || 'View Invoice'}
+        </Button>
+        <Button variant="outline" asChild>
+          <Link href={`/${lang}/admin/panel/sales`}>
+            <ArrowLeft className="mr-2 h-4 w-4" /> {texts.backToList || 'Back to List'}
+          </Link>
+        </Button>
       </CardFooter>
     </Card>
   );

--- a/studio/src/app/[lang]/admin/panel/sales/page.tsx
+++ b/studio/src/app/[lang]/admin/panel/sales/page.tsx
@@ -25,6 +25,7 @@ export default async function AdminSalesPage({ params }: AdminSalesPageProps) {
     tableHeaderPaymentMethod: "Payment Method",
     tableHeaderActions: "Actions",
     viewTicketButton: "View Ticket",
+    viewInvoiceButton: "View Invoice",
     cash: "Cash",
     card: "Card",
     notApplicable: "N/A",

--- a/studio/src/dictionaries/en.json
+++ b/studio/src/dictionaries/en.json
@@ -292,6 +292,7 @@
       "tableHeaderPaymentMethod": "Payment Method",
       "tableHeaderActions": "Actions",
       "viewTicketButton": "View Ticket",
+      "viewInvoiceButton": "View Invoice",
       "cash": "Cash",
       "card": "Card",
       "notApplicable": "N/A",

--- a/studio/src/dictionaries/es.json
+++ b/studio/src/dictionaries/es.json
@@ -292,6 +292,7 @@
       "tableHeaderPaymentMethod": "Método Pago",
       "tableHeaderActions": "Acciones",
       "viewTicketButton": "Ver Ticket",
+      "viewInvoiceButton": "Ver Factura",
       "cash": "Efectivo",
       "card": "Tarjeta",
       "notApplicable": "N/A",

--- a/studio/src/lib/mock-data.ts
+++ b/studio/src/lib/mock-data.ts
@@ -260,6 +260,13 @@ export const mockGetAdminSaleById = async (saleId: string | number): Promise<Sal
   throw simulateApiError('Sale not found', 404);
 };
 
+export const mockGetAdminSaleInvoice = async (saleId: string | number): Promise<string> => {
+  const sale = mockSalesStore.find(s => String(s.id) === String(saleId));
+  if (!sale) throw simulateApiError('Sale not found', 404);
+  const html = `<html><body><h1>Invoice #${sale.numeroTicket}</h1></body></html>`;
+  return simulateApiDelay(html);
+};
+
 // Offers
 export const mockGetOffers = async (): Promise<Offer[]> => simulateApiDelay([...mockOffersStore]);
 

--- a/studio/src/types/index.ts
+++ b/studio/src/types/index.ts
@@ -436,6 +436,7 @@ export type Dictionary = {
       tableHeaderPaymentMethod: string;
       tableHeaderActions: string;
       viewTicketButton: string;
+      viewInvoiceButton: string;
       cash: string;
       card: string;
       notApplicable: string;


### PR DESCRIPTION
## Summary
- support fetching raw HTML via `fetchApiText`
- expose `getAdminSaleInvoice` API function
- mock invoice generation for dev mode
- add "view invoice" button to admin sale detail
- update dictionaries and types

## Testing
- `npm run --prefix studio typecheck` *(fails: Cannot find type definition file for modules)*

------
https://chatgpt.com/codex/tasks/task_e_6877ec2ff9f483258f040539c5b41956