### PR TITLE
Handle sales detail book data

### DIFF
--- a/studio/src/types/index.ts
+++ b/studio/src/types/index.ts
@@ -69,11 +69,12 @@ export interface Cart {
 
 export interface SaleItem {
   id?: number | string; // Optional, depends on DB structure for sale line items
-  libroId: number | string;
+  libroId?: number | string; // Some endpoints may omit this and include a full book
   cantidad: number;
   precioUnitario: number; // Price at the time of sale
   // Optional: include full book object if API sends it nested
-  // libro?: Book;
+  libro?: Book; // Some endpoints use 'libro'
+  book?: Book;  // Others might use 'book'
 }
 
 export interface Sale {


### PR DESCRIPTION
## Summary
- support `book` property in `SaleItem`
- fetch book details when only `book` object is present
- display titles with fallback for `book` field
- allow missing `libroId`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6878017d6a188325a4097beb9c9c2666