### PR TITLE
Fix CardFooter import in stats client

### DIFF
--- a/studio/src/app/[lang]/admin/panel/stats/components/stats-client.tsx
+++ b/studio/src/app/[lang]/admin/panel/stats/components/stats-client.tsx
@@ -10,7 +10,7 @@ import {
   isWithinInterval, subMonths, getMonth, getYear,
 } from 'date-fns';
 import { es as esLocale, enUS as enLocale } from 'date-fns/locale';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";


### PR DESCRIPTION
## Summary
- import `CardFooter` in `StatsClient`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878119f59708325ad0ef57f8518aefe