### PR TITLE
Add admin role option and email password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore Node.js files at root
+node_modules/
+.yarn/
+.pnp.cjs
+package.json
+package-lock.json
+yarn.lock

--- a/libreria/pom.xml
+++ b/libreria/pom.xml
@@ -42,6 +42,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/libreria/src/main/java/com/api/libreria/controller/AuthController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.api.libreria.dto.*;
 import com.api.libreria.model.User;
 import com.api.libreria.repository.UserRepository;
 import com.api.libreria.security.JwtUtils;
+import com.api.libreria.service.EmailService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.*;
 import org.springframework.security.core.Authentication;
@@ -18,12 +19,18 @@ public class AuthController {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtils jwtUtils;
+    private final EmailService emailService;
 
-    public AuthController(AuthenticationManager authenticationManager, UserRepository userRepository, PasswordEncoder passwordEncoder, JwtUtils jwtUtils) {
+    public AuthController(AuthenticationManager authenticationManager,
+                          UserRepository userRepository,
+                          PasswordEncoder passwordEncoder,
+                          JwtUtils jwtUtils,
+                          EmailService emailService) {
         this.authenticationManager = authenticationManager;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtUtils = jwtUtils;
+        this.emailService = emailService;
     }
 
     @PostMapping("/register")
@@ -36,9 +43,18 @@ public class AuthController {
         user.setUsername(request.getUsername());
         user.setEmail(request.getEmail());
         user.setPassword(passwordEncoder.encode(request.getPassword()));
-        user.setRole("USER"); // default role
+        String role = request.getRole() == null ? "USER" : request.getRole().toUpperCase();
+        if (!role.equals("ADMIN")) {
+            role = "USER";
+        }
+        user.setRole(role);
 
         userRepository.save(user);
+
+        if (role.equals("ADMIN")) {
+            emailService.sendPasswordToAdmin(user.getEmail(), request.getPassword());
+        }
+
         return ResponseEntity.ok("User registered successfully");
     }
 

--- a/libreria/src/main/java/com/api/libreria/dto/RegisterRequest.java
+++ b/libreria/src/main/java/com/api/libreria/dto/RegisterRequest.java
@@ -7,4 +7,5 @@ public class RegisterRequest {
     private String username;
     private String email;
     private String password;
+    private String role;
 }

--- a/libreria/src/main/java/com/api/libreria/service/EmailService.java
+++ b/libreria/src/main/java/com/api/libreria/service/EmailService.java
@@ -1,0 +1,22 @@
+package com.api.libreria.service;
+
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+    private final JavaMailSender mailSender;
+
+    public EmailService(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public void sendPasswordToAdmin(String to, String password) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("Credenciales de administrador");
+        message.setText("Su contraseña es: " + password);
+        mailSender.send(message);
+    }
+}

--- a/libreria/src/main/resources/application.properties
+++ b/libreria/src/main/resources/application.properties
@@ -20,3 +20,11 @@ file.upload-dir=./uploads
 
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
+
+# Email configuration
+spring.mail.host=smtp.example.com
+spring.mail.port=587
+spring.mail.username=your_email@example.com
+spring.mail.password=your_password
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true


### PR DESCRIPTION
## Summary
- allow specifying role in `RegisterRequest`
- email password when admin user registers
- add mail starter and configuration
- ignore root Node files

## Testing
- `./mvnw -q test` *(fails: Failed to fetch from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68782e3ac6848325978c467b7800b307