### PR TITLE
Fix undefined field error in POS customer lookup

### DIFF
--- a/studio/src/app/[lang]/admin/panel/pos/components/pos-client.tsx
+++ b/studio/src/app/[lang]/admin/panel/pos/components/pos-client.tsx
@@ -132,7 +132,12 @@ export function PosClient({ lang, dictionary, allBooks, posTexts }: PosClientPro
 
     let customerId = selectedCustomerId;
     if (!customerId && customerName.trim()) {
-      const existing = customers.find(c => c.nombre.toLowerCase() === customerName.toLowerCase() || c.email.toLowerCase() === customerName.toLowerCase());
+      const lower = customerName.toLowerCase();
+      const existing = customers.find(
+        c =>
+          (c.nombre && c.nombre.toLowerCase() === lower) ||
+          (c.email && c.email.toLowerCase() === lower)
+      );
       if (existing) {
         customerId = existing.id;
       } else {


### PR DESCRIPTION
## Summary
- check optional customer name/email fields before calling `toLowerCase`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_687832d085dc83258b12f90dffdf36fa