### PR TITLE
Implement admin dashboard stats

### DIFF
--- a/libreria/src/main/java/com/api/libreria/controller/AdminController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/AdminController.java
@@ -1,5 +1,7 @@
 package com.api.libreria.controller;
 
+import com.api.libreria.dto.DashboardStats;
+import com.api.libreria.service.StatsService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -7,8 +9,19 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/admin")
 public class AdminController {
 
+    private final StatsService statsService;
+
+    public AdminController(StatsService statsService) {
+        this.statsService = statsService;
+    }
+
     @GetMapping("/dashboard")
     public ResponseEntity<String> dashboard() {
         return ResponseEntity.ok("Bienvenido al panel de administración");
+    }
+
+    @GetMapping("/stats")
+    public ResponseEntity<DashboardStats> getStats() {
+        return ResponseEntity.ok(statsService.getDashboardStats());
     }
 }

--- a/libreria/src/main/java/com/api/libreria/dto/DashboardStats.java
+++ b/libreria/src/main/java/com/api/libreria/dto/DashboardStats.java
@@ -1,0 +1,12 @@
+package com.api.libreria.dto;
+
+import lombok.Data;
+
+@Data
+public class DashboardStats {
+    private long booksCount;
+    private double totalSales;
+    private double salesPercentageChange;
+    private long usersCount;
+    private long newUsersThisWeek;
+}

--- a/libreria/src/main/java/com/api/libreria/repository/VentaRepository.java
+++ b/libreria/src/main/java/com/api/libreria/repository/VentaRepository.java
@@ -10,4 +10,11 @@ public interface VentaRepository extends JpaRepository<Venta, Long> {
     Page<Venta> findByUsuarioId(Long usuarioId, Pageable pageable);
 
     Venta findTopByOrderByNumeroTicketDesc();
+
+    @org.springframework.data.jpa.repository.Query("SELECT SUM(v.total) FROM Venta v")
+    Double sumTotalSales();
+
+    @org.springframework.data.jpa.repository.Query("SELECT SUM(v.total) FROM Venta v WHERE v.fecha BETWEEN :start AND :end")
+    Double sumTotalSalesBetween(@org.springframework.data.repository.query.Param("start") java.time.LocalDateTime start,
+                                @org.springframework.data.repository.query.Param("end") java.time.LocalDateTime end);
 }

--- a/libreria/src/main/java/com/api/libreria/service/StatsService.java
+++ b/libreria/src/main/java/com/api/libreria/service/StatsService.java
@@ -1,0 +1,44 @@
+package com.api.libreria.service;
+
+import com.api.libreria.dto.DashboardStats;
+import com.api.libreria.repository.BookRepository;
+import com.api.libreria.repository.UserRepository;
+import com.api.libreria.repository.VentaRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Optional;
+
+@Service
+public class StatsService {
+    private final BookRepository bookRepository;
+    private final UserRepository userRepository;
+    private final VentaRepository ventaRepository;
+
+    public StatsService(BookRepository bookRepository, UserRepository userRepository, VentaRepository ventaRepository) {
+        this.bookRepository = bookRepository;
+        this.userRepository = userRepository;
+        this.ventaRepository = ventaRepository;
+    }
+
+    public DashboardStats getDashboardStats() {
+        DashboardStats stats = new DashboardStats();
+        stats.setBooksCount(bookRepository.count());
+        stats.setUsersCount(userRepository.count());
+        stats.setTotalSales(Optional.ofNullable(ventaRepository.sumTotalSales()).orElse(0.0));
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startOfThisMonth = now.with(TemporalAdjusters.firstDayOfMonth()).withHour(0).withMinute(0).withSecond(0).withNano(0);
+        LocalDateTime startOfLastMonth = startOfThisMonth.minusMonths(1);
+        LocalDateTime endOfLastMonth = startOfThisMonth.minusNanos(1);
+
+        double thisMonth = Optional.ofNullable(ventaRepository.sumTotalSalesBetween(startOfThisMonth, now)).orElse(0.0);
+        double lastMonth = Optional.ofNullable(ventaRepository.sumTotalSalesBetween(startOfLastMonth, endOfLastMonth)).orElse(0.0);
+
+        double change = lastMonth != 0 ? ((thisMonth - lastMonth) / lastMonth) * 100.0 : 0.0;
+        stats.setSalesPercentageChange(change);
+        stats.setNewUsersThisWeek(0L); // Registration date not tracked
+        return stats;
+    }
+}

--- a/studio/src/app/[lang]/admin/panel/page.tsx
+++ b/studio/src/app/[lang]/admin/panel/page.tsx
@@ -4,7 +4,8 @@ import { Button } from "@/components/ui/button";
 import { BookCopy, PlusCircle, LineChart, Users } from "lucide-react";
 import Link from "next/link";
 import { getDictionary } from '@/lib/dictionaries';
-import type { Dictionary } from '@/types'; // Updated import
+import { getDashboardStats } from '@/services/api';
+import type { Dictionary, DashboardStats } from '@/types';
 
 interface AdminDashboardPageProps {
   params: any;
@@ -19,12 +20,25 @@ export default async function AdminDashboardPage({ params: { lang } }: AdminDash
     registeredUsersCard: { title: "Registered Users", usersCount: "{count}", newThisWeek: "+{count} new this week", manageUsersButton: "Manage Users"},
     quickActionsCard: { title: "Quick Actions", addNewBookButton: "Add New Book", generateReportButton: "Generate Sales Report", viewLogsButton: "View System Logs"},
   };
-  // Placeholder data
-  const bookCount = 125;
-  const totalSalesAmount = "1,234.56";
-  const salesPercentage = "10.2";
-  const userCount = 78;
-  const newUsersThisWeek = 5;
+  let stats: DashboardStats = {
+    booksCount: 0,
+    totalSales: 0,
+    salesPercentageChange: 0,
+    usersCount: 0,
+    newUsersThisWeek: 0,
+  };
+
+  try {
+    stats = await getDashboardStats();
+  } catch (error) {
+    console.error('Failed to load dashboard stats', error);
+  }
+
+  const bookCount = stats.booksCount;
+  const totalSalesAmount = stats.totalSales.toFixed(2);
+  const salesPercentage = stats.salesPercentageChange.toFixed(1);
+  const userCount = stats.usersCount;
+  const newUsersThisWeek = stats.newUsersThisWeek;
 
   return (
     <div className="space-y-8">

--- a/studio/src/services/api.ts
+++ b/studio/src/services/api.ts
@@ -1,6 +1,6 @@
 
 import { getAuthHeaders, dispatchLogoutEvent } from '@/lib/auth-utils';
-import type { Book, Category, Editorial, User, Cart, Sale, Offer, CreateSalePayload, CreateOfferPayload, ApiResponseError } from '@/types'; // Ensure all necessary types are imported
+import type { Book, Category, Editorial, User, Cart, Sale, Offer, CreateSalePayload, CreateOfferPayload, ApiResponseError, DashboardStats } from '@/types';
 
 // Import mock functions
 import * as mockApi from '@/lib/mock-data';
@@ -344,6 +344,19 @@ export const getAdminSaleById = async (saleId: string | number): Promise<Sale> =
 export const getAdminSaleInvoice = async (saleId: string | number): Promise<string> => {
   if (API_MODE === 'mock') return mockApi.mockGetAdminSaleInvoice(saleId);
   return fetchApiText(`/api/ventas/admin/${saleId}/invoice`, { headers: { Accept: 'text/html' } });
+};
+
+export const getDashboardStats = async (): Promise<DashboardStats> => {
+  if (API_MODE === 'mock') {
+    return {
+      booksCount: 125,
+      totalSales: 1234.56,
+      salesPercentageChange: 10.2,
+      usersCount: 78,
+      newUsersThisWeek: 5,
+    };
+  }
+  return fetchApi<DashboardStats>('/api/admin/stats');
 };
 
 

--- a/studio/src/types/index.ts
+++ b/studio/src/types/index.ts
@@ -132,6 +132,14 @@ export interface ApiResponseError {
   statusCode?: number;
 }
 
+export interface DashboardStats {
+  booksCount: number;
+  totalSales: number;
+  salesPercentageChange: number;
+  usersCount: number;
+  newUsersThisWeek: number;
+}
+
 
 // --- Potentially Unused Types (Review and Remove if Confirm Unused) ---
 // These types (GenAICartItem, GenAIAvailableOffer) seemed to be for mock data or a different feature.


### PR DESCRIPTION
## Summary
- expose backend stats API to return book, sales, and user totals
- calculate totals in new `StatsService`
- support totals in `VentaRepository`
- expose `DashboardStats` DTO and TS interface
- fetch dashboard stats on the admin panel page

## Testing
- `npm run lint` *(fails: next not found)*
- `./mvnw -q test` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687837c6c1288325b7e3c3470d6998ab