### PR TITLE
Fix admin page auth headers

### DIFF
--- a/studio/src/lib/auth-utils.ts
+++ b/studio/src/lib/auth-utils.ts
@@ -1,5 +1,13 @@
+import { cookies } from 'next/headers';
+
 export const getAuthHeaders = (): Record<string, string> => {
-  const token = typeof window !== 'undefined' ? localStorage.getItem('authToken') : null;
+  let token: string | null | undefined = null;
+
+  if (typeof window !== 'undefined') {
+    token = localStorage.getItem('authToken');
+  } else {
+    token = cookies().get('authToken')?.value;
+  }
 
   const headers: Record<string, string> = {};
 


### PR DESCRIPTION
## Summary
- include cookies when building auth headers so server components have credentials

## Testing
- `npm test --silent` *(fails: no tests)*
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68783ba00b4c8325bf90c31ff06c1aeb