### PR TITLE
Fix shared util for client/server

### DIFF
--- a/studio/src/lib/auth-utils.ts
+++ b/studio/src/lib/auth-utils.ts
@@ -1,12 +1,22 @@
-import { cookies } from 'next/headers';
+// Importing `cookies` from `next/headers` directly would make this file
+// server-only. Instead, we dynamically load it when running on the server so
+// that this utility can be used in Client Components as well.
 
-export const getAuthHeaders = (): Record<string, string> => {
+// Type for the dynamically imported `cookies` function
+type CookiesFn = typeof import('next/headers').cookies;
+
+export const getAuthHeaders = async (): Promise<Record<string, string>> => {
   let token: string | null | undefined = null;
 
   if (typeof window !== 'undefined') {
     token = localStorage.getItem('authToken');
   } else {
-    token = cookies().get('authToken')?.value;
+    try {
+      const { cookies }: { cookies: CookiesFn } = await import('next/headers');
+      token = cookies().get('authToken')?.value;
+    } catch {
+      token = null;
+    }
   }
 
   const headers: Record<string, string> = {};

--- a/studio/src/services/api.ts
+++ b/studio/src/services/api.ts
@@ -19,7 +19,7 @@ interface FetchApiOptions extends RequestInit {
 
 async function fetchApi<T>(endpoint: string, options: FetchApiOptions = {}): Promise<T> {
   const url = `${API_BASE_URL}${endpoint}`;
-  const authHeaders = getAuthHeaders();
+  const authHeaders = await getAuthHeaders();
 
   const headers: Record<string, string> = {
     ...authHeaders,
@@ -76,7 +76,7 @@ async function fetchApi<T>(endpoint: string, options: FetchApiOptions = {}): Pro
 
 async function fetchApiText(endpoint: string, options: FetchApiOptions = {}): Promise<string> {
   const url = `${API_BASE_URL}${endpoint}`;
-  const authHeaders = getAuthHeaders();
+  const authHeaders = await getAuthHeaders();
 
   const headers: Record<string, string> = {
     ...authHeaders,


### PR DESCRIPTION
## Summary
- avoid server-only `next/headers` import in shared auth util
- make API service await async header retrieval

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68783ceba81c83258362f71b7a533a88