### PR TITLE
Fix infinite JSON recursion for orders

### DIFF
--- a/libreria/src/main/java/com/api/libreria/model/Order.java
+++ b/libreria/src/main/java/com/api/libreria/model/Order.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -30,5 +31,6 @@ public class Order {
     private String status;  // Ej: "PENDING", "COMPLETED", "CANCELLED"
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
     private List<OrderItem> items;
 }

--- a/libreria/src/main/java/com/api/libreria/model/OrderItem.java
+++ b/libreria/src/main/java/com/api/libreria/model/OrderItem.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 
 @Entity
 @Table(name = "order_items")
@@ -18,6 +19,7 @@ public class OrderItem {
 
     @ManyToOne
     @JoinColumn(name = "order_id")
+    @JsonBackReference
     private Order order;
 
     @ManyToOne

--- a/libreria/src/main/java/com/api/libreria/model/Pedido.java
+++ b/libreria/src/main/java/com/api/libreria/model/Pedido.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,5 +30,6 @@ public class Pedido {
     private String status;
 
     @OneToMany(mappedBy = "pedido", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
     private List<PedidoItem> items;
 }

--- a/libreria/src/main/java/com/api/libreria/model/PedidoItem.java
+++ b/libreria/src/main/java/com/api/libreria/model/PedidoItem.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 
 @Entity
 @Table(name = "pedido_items")
@@ -17,6 +18,7 @@ public class PedidoItem {
 
     @ManyToOne
     @JoinColumn(name = "pedido_id")
+    @JsonBackReference
     private Pedido pedido;
 
     @ManyToOne


### PR DESCRIPTION
## Summary
- prevent recursion in order/pedido serialization by using `JsonManagedReference`/`JsonBackReference`

## Testing
- `./mvnw test -q` *(fails: Failed to fetch ... due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68785d4d26008325ac2f2fb555d8b38d