### PR TITLE
Add admin order approval and cancellation

### DIFF
--- a/libreria/src/main/java/com/api/libreria/service/PedidoService.java
+++ b/libreria/src/main/java/com/api/libreria/service/PedidoService.java
@@ -15,13 +15,16 @@ public class PedidoService {
     private final PedidoRepository pedidoRepository;
     private final PedidoItemRepository pedidoItemRepository;
     private final BookRepository bookRepository;
+    private final VentaService ventaService;
 
     public PedidoService(PedidoRepository pedidoRepository,
                          PedidoItemRepository pedidoItemRepository,
-                         BookRepository bookRepository) {
+                         BookRepository bookRepository,
+                         VentaService ventaService) {
         this.pedidoRepository = pedidoRepository;
         this.pedidoItemRepository = pedidoItemRepository;
         this.bookRepository = bookRepository;
+        this.ventaService = ventaService;
     }
 
     @Transactional
@@ -59,6 +62,10 @@ public class PedidoService {
     public Pedido actualizarEstado(Long id, String status) {
         Pedido p = pedidoRepository.findById(id).orElseThrow();
         p.setStatus(status);
-        return pedidoRepository.save(p);
+        Pedido saved = pedidoRepository.save(p);
+        if ("APPROVED".equalsIgnoreCase(status)) {
+            ventaService.crearVentaDesdePedido(saved);
+        }
+        return saved;
     }
 }

--- a/studio/src/app/[lang]/admin/panel/orders/components/orders-list-client.tsx
+++ b/studio/src/app/[lang]/admin/panel/orders/components/orders-list-client.tsx
@@ -26,6 +26,11 @@ export function OrdersListClient({ texts }: { texts: any }) {
     await load();
   };
 
+  const handleCancel = async (id: number | string) => {
+    await updatePedidoStatus(id, 'CANCELLED');
+    await load();
+  };
+
   if (loading) return <p>Loading...</p>;
   if (orders.length === 0) return <p>No orders found.</p>;
 
@@ -45,9 +50,12 @@ export function OrdersListClient({ texts }: { texts: any }) {
             <TableCell>{o.id}</TableCell>
             <TableCell>{o.nombre}</TableCell>
             <TableCell>{o.status}</TableCell>
-            <TableCell>
+            <TableCell className="space-x-2">
               {o.status !== 'APPROVED' && (
-                <Button size="sm" onClick={() => handleApprove(o.id)}>Approve</Button>
+                <Button size="sm" onClick={() => handleApprove(o.id)}>{texts?.approve || 'Approve'}</Button>
+              )}
+              {o.status !== 'CANCELLED' && (
+                <Button variant="destructive" size="sm" onClick={() => handleCancel(o.id)}>{texts?.cancel || 'Cancel'}</Button>
               )}
             </TableCell>
           </TableRow>

--- a/studio/src/dictionaries/en.json
+++ b/studio/src/dictionaries/en.json
@@ -344,7 +344,9 @@
     },
     "ordersPage": {
       "title": "Orders",
-      "customerName": "Customer"
+      "customerName": "Customer",
+      "approve": "Approve",
+      "cancel": "Cancel"
     },
     "statsPage": {
       "title": "Sales Statistics",

--- a/studio/src/dictionaries/es.json
+++ b/studio/src/dictionaries/es.json
@@ -344,7 +344,9 @@
     },
     "ordersPage": {
       "title": "Pedidos",
-      "customerName": "Cliente"
+      "customerName": "Cliente",
+      "approve": "Aprobar",
+      "cancel": "Cancelar"
     },
     "statsPage": {
       "title": "Estadísticas de Ventas",


### PR DESCRIPTION
## Summary
- enable canceling or approving orders in admin panel
- generate a sale when an order is approved
- add translations for approve/cancel buttons

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68785f505c5c8325a9cf090ce9bf62b5