### PR TITLE
Add order details dialog to admin panel

### DIFF
--- a/studio/src/app/[lang]/admin/panel/orders/components/order-details-dialog.tsx
+++ b/studio/src/app/[lang]/admin/panel/orders/components/order-details-dialog.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from 'react';
+import type { Pedido } from '@/types';
+import { updatePedidoStatus } from '@/services/api';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogFooter,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+interface OrderDetailsDialogProps {
+  order: Pedido | null;
+  onClose: () => void;
+  texts: any;
+  onStatusUpdated: () => void;
+}
+
+export function OrderDetailsDialog({ order, onClose, texts, onStatusUpdated }: OrderDetailsDialogProps) {
+  const [status, setStatus] = useState(order?.status || 'PENDING');
+
+  if (!order) return null;
+
+  const handleUpdate = async () => {
+    await updatePedidoStatus(order.id, status);
+    onStatusUpdated();
+    onClose();
+  };
+
+  return (
+    <AlertDialog open={!!order} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <AlertDialogContent className="max-w-lg">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="font-headline text-2xl text-primary">
+            {texts.orderDetailsTitle || 'Order Details'}
+          </AlertDialogTitle>
+        </AlertDialogHeader>
+        <div className="space-y-1 text-sm mt-2">
+          <p><strong>ID:</strong> {order.id}</p>
+          <p><strong>{texts.customerName || 'Customer'}:</strong> {order.nombre} ({order.email})</p>
+          <p><strong>Address:</strong> {order.direccion}, {order.ciudad}, {order.estado} {order.zip}</p>
+        </div>
+        <div className="mt-4">
+          <h4 className="font-semibold mb-2">{texts.items || 'Items'}</h4>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Book</TableHead>
+                <TableHead className="text-center">Qty</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {order.items.map((item) => (
+                <TableRow key={item.id}>
+                  <TableCell>{item.libro?.titulo || item.book?.titulo || `ID ${item.libroId || item.book?.id}`}</TableCell>
+                  <TableCell className="text-center">{item.cantidad}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+        <div className="mt-4 space-y-2">
+          <label className="block text-sm font-medium">{texts.status || 'Status'}</label>
+          <Select value={status} onValueChange={setStatus}>
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="PENDING">PENDING</SelectItem>
+              <SelectItem value="APPROVED">APPROVED</SelectItem>
+              <SelectItem value="CANCELLED">CANCELLED</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button onClick={handleUpdate} className="w-full">
+            {texts.updateStatus || 'Update Status'}
+          </Button>
+        </div>
+        <AlertDialogFooter className="mt-4">
+          <Button variant="outline" onClick={onClose}>{texts.closeButton || 'Close'}</Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/studio/src/app/[lang]/admin/panel/orders/components/orders-list-client.tsx
+++ b/studio/src/app/[lang]/admin/panel/orders/components/orders-list-client.tsx
@@ -4,10 +4,12 @@ import { getAdminPedidos, updatePedidoStatus } from '@/services/api';
 import type { Pedido } from '@/types';
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
+import { OrderDetailsDialog } from './order-details-dialog';
 
 export function OrdersListClient({ texts }: { texts: any }) {
   const [orders, setOrders] = useState<Pedido[]>([]);
   const [loading, setLoading] = useState(true);
+  const [selectedOrder, setSelectedOrder] = useState<Pedido | null>(null);
 
   const load = async () => {
     setLoading(true);
@@ -35,32 +37,43 @@ export function OrdersListClient({ texts }: { texts: any }) {
   if (orders.length === 0) return <p>No orders found.</p>;
 
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>ID</TableHead>
-          <TableHead>{texts?.customerName || 'Customer'}</TableHead>
-          <TableHead>Status</TableHead>
-          <TableHead>Actions</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {orders.map(o => (
-          <TableRow key={o.id}>
-            <TableCell>{o.id}</TableCell>
-            <TableCell>{o.nombre}</TableCell>
-            <TableCell>{o.status}</TableCell>
-            <TableCell className="space-x-2">
-              {o.status !== 'APPROVED' && (
-                <Button size="sm" onClick={() => handleApprove(o.id)}>{texts?.approve || 'Approve'}</Button>
-              )}
-              {o.status !== 'CANCELLED' && (
-                <Button variant="destructive" size="sm" onClick={() => handleCancel(o.id)}>{texts?.cancel || 'Cancel'}</Button>
-              )}
-            </TableCell>
+    <>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>ID</TableHead>
+            <TableHead>{texts?.customerName || 'Customer'}</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Actions</TableHead>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHeader>
+        <TableBody>
+          {orders.map(o => (
+            <TableRow key={o.id}>
+              <TableCell>{o.id}</TableCell>
+              <TableCell>{o.nombre}</TableCell>
+              <TableCell>{o.status}</TableCell>
+              <TableCell className="space-x-2">
+                <Button variant="outline" size="sm" onClick={() => setSelectedOrder(o)}>
+                  {texts?.viewDetails || 'View Details'}
+                </Button>
+                {o.status !== 'APPROVED' && (
+                  <Button size="sm" onClick={() => handleApprove(o.id)}>{texts?.approve || 'Approve'}</Button>
+                )}
+                {o.status !== 'CANCELLED' && (
+                  <Button variant="destructive" size="sm" onClick={() => handleCancel(o.id)}>{texts?.cancel || 'Cancel'}</Button>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <OrderDetailsDialog
+        order={selectedOrder}
+        onClose={() => setSelectedOrder(null)}
+        texts={texts}
+        onStatusUpdated={load}
+      />
+    </>
   );
 }

--- a/studio/src/dictionaries/en.json
+++ b/studio/src/dictionaries/en.json
@@ -346,7 +346,12 @@
       "title": "Orders",
       "customerName": "Customer",
       "approve": "Approve",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "viewDetails": "View Details",
+      "closeButton": "Close",
+      "items": "Items",
+      "status": "Status",
+      "updateStatus": "Update Status"
     },
     "statsPage": {
       "title": "Sales Statistics",

--- a/studio/src/dictionaries/es.json
+++ b/studio/src/dictionaries/es.json
@@ -346,7 +346,12 @@
       "title": "Pedidos",
       "customerName": "Cliente",
       "approve": "Aprobar",
-      "cancel": "Cancelar"
+      "cancel": "Cancelar",
+      "viewDetails": "Ver Detalles",
+      "closeButton": "Cerrar",
+      "items": "Artículos",
+      "status": "Estado",
+      "updateStatus": "Actualizar Estado"
     },
     "statsPage": {
       "title": "Estadísticas de Ventas",

--- a/studio/src/types/index.ts
+++ b/studio/src/types/index.ts
@@ -501,10 +501,17 @@ export type Dictionary = {
         september: string; october: string; november: string; december: string;
       };
     };
-    ordersPage: {
-      title: string;
-      customerName: string;
-    };
+      ordersPage: {
+        title: string;
+        customerName: string;
+        approve?: string;
+        cancel?: string;
+        viewDetails?: string;
+        closeButton?: string;
+        items?: string;
+        status?: string;
+        updateStatus?: string;
+      };
     statsPage: {
       title: string;
       salesOverTimeTitle: string;


### PR DESCRIPTION
## Summary
- extend dictionary with texts for order details
- update TypeScript types for new dictionary fields
- implement `OrderDetailsDialog` with status update
- integrate dialog into orders list

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68786607bf708325aa9bb2e8e12fb1a6