### PR TITLE
Adjust stock when creating orders

### DIFF
--- a/libreria/src/main/java/com/api/libreria/service/PedidoService.java
+++ b/libreria/src/main/java/com/api/libreria/service/PedidoService.java
@@ -44,9 +44,16 @@ public class PedidoService {
         if (request.getItems() != null) {
             var items = new ArrayList<PedidoItem>();
             for (CreatePedidoItemRequest itemReq : request.getItems()) {
+                Book book = bookRepository.findById(itemReq.getLibroId()).orElseThrow();
+                if (book.getStock() < itemReq.getCantidad()) {
+                    throw new RuntimeException("Stock insuficiente para: " + book.getTitulo());
+                }
+                book.setStock(book.getStock() - itemReq.getCantidad());
+                bookRepository.save(book);
+
                 PedidoItem item = new PedidoItem();
                 item.setPedido(pedido);
-                item.setBook(bookRepository.findById(itemReq.getLibroId()).orElseThrow());
+                item.setBook(book);
                 item.setCantidad(itemReq.getCantidad());
                 items.add(pedidoItemRepository.save(item));
             }

--- a/libreria/src/main/java/com/api/libreria/service/VentaService.java
+++ b/libreria/src/main/java/com/api/libreria/service/VentaService.java
@@ -150,11 +150,8 @@ public class VentaService  {
         double total = 0.0;
         for (PedidoItem item : pedido.getItems()) {
             Book book = item.getBook();
-            if (book.getStock() < item.getCantidad()) {
-                throw new RuntimeException("Stock insuficiente para: " + book.getTitulo());
-            }
-            book.setStock(book.getStock() - item.getCantidad());
-            bookRepository.save(book);
+
+            // El stock ya fue descontado al crear el pedido
 
             VentaItem ventaItem = new VentaItem();
             ventaItem.setVenta(venta);


### PR DESCRIPTION
## Summary
- decrement book stock during order creation
- avoid double stock deduction when converting an order to a sale

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68793b26e19c8325a38c9215bb76b1ac