### PR TITLE
Restore stock when cancelling pedidos

### DIFF
--- a/libreria/src/main/java/com/api/libreria/service/PedidoService.java
+++ b/libreria/src/main/java/com/api/libreria/service/PedidoService.java
@@ -69,10 +69,18 @@ public class PedidoService {
     @Transactional
     public Pedido actualizarEstado(Long id, String status) {
         Pedido p = pedidoRepository.findById(id).orElseThrow();
+        String previousStatus = p.getStatus();
         p.setStatus(status);
         Pedido saved = pedidoRepository.save(p);
         if ("APPROVED".equalsIgnoreCase(status)) {
             ventaService.crearVentaDesdePedido(saved);
+        } else if ("CANCELLED".equalsIgnoreCase(status) &&
+                   !"CANCELLED".equalsIgnoreCase(previousStatus)) {
+            for (PedidoItem item : saved.getItems()) {
+                Book book = item.getBook();
+                book.setStock(book.getStock() + item.getCantidad());
+                bookRepository.save(book);
+            }
         }
         return saved;
     }


### PR DESCRIPTION
## Summary
- add logic to return book stock when a `Pedido` is cancelled

## Testing
- `./mvnw -q test` *(fails: unable to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68793cbee30c8325a968914d441b5f73