### PR TITLE
Enable guest checkout with automatic account creation

### DIFF
--- a/libreria/src/main/java/com/api/libreria/service/PedidoService.java
+++ b/libreria/src/main/java/com/api/libreria/service/PedidoService.java
@@ -2,6 +2,7 @@ package com.api.libreria.service;
 
 import com.api.libreria.model.*;
 import com.api.libreria.repository.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import com.api.libreria.dto.CreatePedidoItemRequest;
 import com.api.libreria.dto.CreatePedidoRequest;
 import org.springframework.stereotype.Service;
@@ -16,19 +17,35 @@ public class PedidoService {
     private final PedidoItemRepository pedidoItemRepository;
     private final BookRepository bookRepository;
     private final VentaService ventaService;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public PedidoService(PedidoRepository pedidoRepository,
                          PedidoItemRepository pedidoItemRepository,
                          BookRepository bookRepository,
-                         VentaService ventaService) {
+                         VentaService ventaService,
+                         UserRepository userRepository,
+                         PasswordEncoder passwordEncoder) {
         this.pedidoRepository = pedidoRepository;
         this.pedidoItemRepository = pedidoItemRepository;
         this.bookRepository = bookRepository;
         this.ventaService = ventaService;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @Transactional
     public Pedido crearPedido(CreatePedidoRequest request) {
+        // Create or fetch user based on email
+        userRepository.findByEmail(request.getEmail()).orElseGet(() -> {
+            User newUser = new User();
+            newUser.setUsername(request.getNombre());
+            newUser.setEmail(request.getEmail());
+            newUser.setPassword(passwordEncoder.encode(java.util.UUID.randomUUID().toString()));
+            newUser.setRole("USER");
+            return userRepository.save(newUser);
+        });
+
         Pedido pedido = new Pedido();
         pedido.setNombre(request.getNombre());
         pedido.setEmail(request.getEmail());

--- a/studio/src/app/[lang]/checkout/components/checkout-form-client.tsx
+++ b/studio/src/app/[lang]/checkout/components/checkout-form-client.tsx
@@ -39,7 +39,7 @@ interface CheckoutFormClientProps {
 export function CheckoutFormClient({ lang, dictionary }: CheckoutFormClientProps) {
   // Use the new cart structure from useCart
   const { cart, getCartTotal, clearCart: clearCartContextAction, isLoading: isCartLoadingHook, error: cartErrorHook } = useCart(); 
-  const { isAuthenticated, user } = useAuth();
+  const { user } = useAuth();
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false); // Renamed isLoading to isSubmitting for clarity
   const [isOrderSubmitted, setIsOrderSubmitted] = useState(false);
@@ -107,13 +107,6 @@ export function CheckoutFormClient({ lang, dictionary }: CheckoutFormClientProps
 
   const onSubmit: SubmitHandler<CheckoutFormData> = async (data) => {
     setSubmissionError(null);
-    if (!isAuthenticated) {
-      setSubmissionError("You must be logged in to place an order.");
-      toast({ title: "Authentication Error", description: "Please log in to continue.", variant: "destructive" });
-      // Optionally redirect to login: router.push(`/${lang}/login`);
-      return;
-    }
-
     if (!cart || cart.items.length === 0) {
       setSubmissionError("Your cart is empty.");
       toast({ title: "Empty Cart", description: "Cannot place an order with an empty cart.", variant: "destructive" });


### PR DESCRIPTION
## Summary
- create users automatically when a checkout (pedido) is performed
- allow checkout page to work without requiring authentication

## Testing
- `./mvnw -q test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68793d0668148325957820b1fb60872c