### PR TITLE
Fix cart stock handling

### DIFF
--- a/studio/src/app/[lang]/cart/components/cart-item-row-client.tsx
+++ b/studio/src/app/[lang]/cart/components/cart-item-row-client.tsx
@@ -26,11 +26,10 @@ export function CartItemRowClient({ item, lang, dictionary }: CartItemRowClientP
   const bookDetails = item.libro; // The 'libro' field should contain book details
 
   const handleQuantityChange = async (newQuantity: number) => {
-    // Use libroId for cart actions since context functions expect it
     if (!item.libroId) return;
     setIsUpdating(true);
-    // Ensure newQuantity is at least 1, or handle removal if 0
-    const quantityToUpdate = Math.max(1, newQuantity);
+    const maxStock = bookDetails?.stock ?? newQuantity;
+    const quantityToUpdate = Math.max(1, Math.min(newQuantity, maxStock));
     await updateItemQuantity(item.libroId, quantityToUpdate);
     setIsUpdating(false);
   };
@@ -102,15 +101,14 @@ export function CartItemRowClient({ item, lang, dictionary }: CartItemRowClientP
             }}
             className="w-16 text-center h-10"
             min="1"
-            // max={bookDetails.stock} // Stock check should ideally be handled by API or disabled if not available
+            max={bookDetails?.stock}
             disabled={isUpdating || isCartLoading}
           />
           <Button 
             variant="outline" 
             size="icon" 
-            onClick={() => handleQuantityChange(item.cantidad + 1)} 
-            // disabled={item.cantidad >= bookDetails.stock || isUpdating || isCartLoading}  // Stock check
-            disabled={isUpdating || isCartLoading} 
+            onClick={() => handleQuantityChange(item.cantidad + 1)}
+            disabled={item.cantidad >= (bookDetails?.stock ?? Infinity) || isUpdating || isCartLoading}
           >
              {isUpdating && item.cantidad +1 === item.cantidad +1 ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
           </Button>

--- a/studio/src/context/cart-provider.tsx
+++ b/studio/src/context/cart-provider.tsx
@@ -76,15 +76,17 @@ export function CartProvider({ children }: CartProviderProps) {
         const existing = current.items.find(i => String(i.libroId) === String(bookId));
         let newItems: CartItem[];
         if (existing) {
+          const maxQty = Math.min(existing.cantidad + quantity, book.stock);
           newItems = current.items.map(i =>
             String(i.libroId) === String(bookId)
-              ? { ...i, cantidad: i.cantidad + quantity }
+              ? { ...i, cantidad: maxQty }
               : i,
           );
         } else {
+          const allowedQty = Math.min(quantity, book.stock);
           const newItem: CartItem = {
             libroId: bookId,
-            cantidad: quantity,
+            cantidad: allowedQty,
             precioUnitario: book.precio,
             libro: book,
           };
@@ -118,8 +120,11 @@ export function CartProvider({ children }: CartProviderProps) {
     }
     setCart(prev => {
       if (!prev) return prev;
+      const item = prev.items.find(i => String(i.libroId) === String(itemId));
+      const stockLimit = item?.libro?.stock ?? newQuantity;
+      const qty = Math.min(newQuantity, stockLimit);
       const newItems = prev.items.map(i =>
-        String(i.libroId) === String(itemId) ? { ...i, cantidad: newQuantity } : i,
+        String(i.libroId) === String(itemId) ? { ...i, cantidad: qty } : i,
       );
       const newCart = { ...prev, items: newItems };
       newCart.total = newItems.reduce((t, it) => t + it.precioUnitario * it.cantidad, 0);


### PR DESCRIPTION
## Summary
- prevent adding more items than book stock in cart provider
- enforce max stock in cart item quantity controls

## Testing
- `npm install` *(fails: network access blocked)*
- `npm run lint` *(fails: `next` not found without dependencies)*
- `npm run typecheck` *(fails due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68793d543e14832599f0b635d2af738f