### PR TITLE
Show category name in book detail

### DIFF
--- a/libreria/src/main/java/com/api/libreria/controller/CategoriaController.java
+++ b/libreria/src/main/java/com/api/libreria/controller/CategoriaController.java
@@ -23,6 +23,13 @@ public class CategoriaController {
         return categoriaRepository.findAll(pageable);
     }
 
+    @GetMapping("/{id}")
+    public ResponseEntity<Categoria> getById(@PathVariable Long id) {
+        return categoriaRepository.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Categoria> create(@RequestBody Categoria categoria) {

--- a/studio/src/app/[lang]/books/[id]/page.tsx
+++ b/studio/src/app/[lang]/books/[id]/page.tsx
@@ -1,7 +1,7 @@
 
 import { PublicLayout } from '@/components/layout/public-layout';
 // Import the new getBookById from API service
-import { getBookById, getBooks } from '@/services/api'; 
+import { getBookById, getBooks, getCategoryById } from '@/services/api';
 import { notFound } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 // Keep Category and Editorial types if you plan to fetch and display their names
@@ -46,10 +46,19 @@ export default async function BookDetailPage({ params }: BookDetailPageProps) {
   const { id, lang } = params;
   const dictionary = await getDictionary(lang);
   let book: Book | null = null;
+  let categoryName: string | null = null;
   let fetchError: string | null = null;
 
   try {
     book = await getBookById(id);
+    if (book?.categoriaId) {
+      try {
+        const category = await getCategoryById(book.categoriaId);
+        categoryName = category.nombre;
+      } catch (catErr) {
+        console.error(`Failed to fetch category with ID ${book.categoriaId}:`, catErr);
+      }
+    }
   } catch (error: any) {
     console.error(`Failed to fetch book with ID ${id}:`, error);
     if (error.statusCode === 404 || error.status === 404) { // Check for error.status for fetch API errors
@@ -108,7 +117,11 @@ export default async function BookDetailPage({ params }: BookDetailPageProps) {
             </p>
             
             <div className="flex items-center space-x-2">
-              {book.categoriaId && <Badge variant="secondary" className="text-sm px-3 py-1">Category ID: {book.categoriaId}</Badge>}
+              {book.categoriaId && (
+                <Badge variant="secondary" className="text-sm px-3 py-1">
+                  {categoryName || `Category ID: ${book.categoriaId}`}
+                </Badge>
+              )}
             </div>
 
             <p className="text-lg text-foreground/90 leading-relaxed">{book.descripcion || "No description available."}</p>

--- a/studio/src/lib/mock-data.ts
+++ b/studio/src/lib/mock-data.ts
@@ -130,6 +130,11 @@ export const mockDeleteBook = async (id: string | number): Promise<void> => {
 
 // Categories
 export const mockGetCategories = async (): Promise<Category[]> => simulateApiDelay([...mockCategoriesStore]);
+export const mockGetCategoryById = async (id: string | number): Promise<Category> => {
+  const category = mockCategoriesStore.find(c => String(c.id) === String(id));
+  if (category) return simulateApiDelay(category);
+  throw simulateApiError('Category not found', 404);
+};
 export const mockCreateCategory = async (catData: Partial<Category>): Promise<Category> => {
   const newCategory: Category = { id: generateId(), nombre: catData.nombre || 'Nueva Categoría', ...catData };
   mockCategoriesStore.push(newCategory);

--- a/studio/src/services/api.ts
+++ b/studio/src/services/api.ts
@@ -229,6 +229,11 @@ export const getCategories = async (
   return page.content;
 };
 
+export const getCategoryById = async (id: string | number): Promise<Category> => {
+  if (API_MODE === 'mock') return mockApi.mockGetCategoryById(id);
+  return fetchApi<Category>(`/api/categorias/${id}`);
+};
+
 export const createCategory = async (categoryData: Partial<Category>): Promise<Category> => {
   if (API_MODE === 'mock') return mockApi.mockCreateCategory(categoryData);
   return fetchApi<Category>('/api/categorias', {


### PR DESCRIPTION
## Summary
- add endpoint to fetch category by id
- expose getCategoryById API helper and mock function
- fetch the category name when rendering a book and display it

## Testing
- `mvn test` *(fails: `mvn: command not found`)*
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687942b8d0c883259faf331385518a5a