### PR TITLE
Add pagination to editorial admin list

### DIFF
--- a/studio/src/app/[lang]/admin/panel/editorials/components/editorial-list-client.tsx
+++ b/studio/src/app/[lang]/admin/panel/editorials/components/editorial-list-client.tsx
@@ -1,121 +1,159 @@
-
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import type { Editorial } from '@/types';
 import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Edit, Trash2, PlusCircle, Building2 } from 'lucide-react';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
+import { Edit, Trash2, PlusCircle, Building2, Search } from 'lucide-react';
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
+import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
 
 interface EditorialListClientProps {
-  editorials: Editorial[]; // Changed from initialEditorials
-  onDeleteEditorial: (editorialId: string | number) => Promise<void>; // ID can be string or number
+  editorials: Editorial[];
+  onDeleteEditorial: (editorialId: string | number) => Promise<void>;
   lang: string;
-  texts: any; // Dictionary texts for editorials
+  texts: any;
 }
 
 export function EditorialListClient({ editorials, onDeleteEditorial, lang, texts }: EditorialListClientProps) {
-  // Removed local editorials state, use prop directly
   const [editorialToDelete, setEditorialToDelete] = useState<Editorial | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [page, setPage] = useState(1);
+  const pageSize = 10;
   const { toast } = useToast();
 
-  // No longer need useEffect to setEditorials
-
   const handleDeleteConfirmation = async () => {
-    if (editorialToDelete && editorialToDelete.id) { // Ensure ID exists
+    if (editorialToDelete && editorialToDelete.id) {
       try {
-        await onDeleteEditorial(editorialToDelete.id); 
-        // Parent component will re-fetch and pass updated 'editorials'
-        toast({ title: texts.toastEditorialDeleted || "Publisher Deleted", description: `${editorialToDelete.nombre} has been deleted.` }); // Use nombre
-      } catch (error) {
-        // Error toast is handled by parent
-        // toast({ title: texts.toastError || "Error", description: `Failed to delete ${editorialToDelete.nombre}.`, variant: "destructive" });
+        await onDeleteEditorial(editorialToDelete.id);
+        toast({
+          title: texts.toastEditorialDeleted || 'Publisher Deleted',
+          description: `${editorialToDelete.nombre} has been deleted.`,
+        });
       } finally {
         setEditorialToDelete(null);
       }
     }
   };
 
+  const filtered = editorials.filter(e =>
+    e.nombre.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    (e.rut && e.rut.toLowerCase().includes(searchTerm.toLowerCase())) ||
+    (e.celular && e.celular.toLowerCase().includes(searchTerm.toLowerCase()))
+  );
+  const totalPages = Math.ceil(filtered.length / pageSize) || 1;
+  const paged = filtered.slice((page - 1) * pageSize, page * pageSize);
+
   return (
-    <AlertDialog open={!!editorialToDelete} onOpenChange={(open) => { if (!open) setEditorialToDelete(null); }}>
+    <AlertDialog
+      open={!!editorialToDelete}
+      onOpenChange={open => {
+        if (!open) setEditorialToDelete(null);
+      }}
+    >
       <div className="space-y-6">
-        <div className="flex justify-end items-center">
+        <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
+          <div className="relative w-full sm:max-w-md">
+            <Input
+              type="text"
+              placeholder="Search publishers..."
+              value={searchTerm}
+              onChange={e => {
+                setSearchTerm(e.target.value);
+                setPage(1);
+              }}
+              className="pl-10"
+            />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground" />
+          </div>
           <Link href={`/${lang}/admin/panel/editorials?action=add`} passHref legacyBehavior>
             <Button>
-              <PlusCircle className="mr-2 h-4 w-4" /> {texts.addNewEditorial || "Add New Publisher"}
+              <PlusCircle className="mr-2 h-4 w-4" /> {texts.addNewEditorial || 'Add New Publisher'}
             </Button>
           </Link>
         </div>
 
-        {editorials.length > 0 ? (
-          <Table>
-            <TableHeader>
-              <TableRow><TableHead>{texts.tableHeaderName || "Name"}</TableHead>
-                <TableHead>{texts.tableHeaderRut || 'RUT'}</TableHead>
-                <TableHead>{texts.tableHeaderCelular || 'Cellphone'}</TableHead>
-                <TableHead>Website</TableHead>
-                <TableHead className="text-center">{texts.tableHeaderActions || "Actions"}</TableHead></TableRow>
-            </TableHeader>
-            <TableBody>
-              {editorials.map((editorial) => (
-                <TableRow key={editorial.id}><TableCell className="font-medium">{editorial.nombre}</TableCell> {/* Use nombre */}
-                  <TableCell>{editorial.rut || '-'}</TableCell>
-                  <TableCell>{editorial.celular || '-'}</TableCell>
-                  <TableCell>
-                    {editorial.sitioWeb ? (
-                      <a href={editorial.sitioWeb} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
-                        {editorial.sitioWeb}
-                      </a>
-                    ) : '-'}
-                  </TableCell>
-                  {/* <TableCell>{editorial.email || '-'}</TableCell> */}
-                  <TableCell className="text-center space-x-1">
-                    <Link href={`/${lang}/admin/panel/editorials?action=edit&id=${editorial.id}`} passHref legacyBehavior>
-                      <Button variant="ghost" size="icon" title={texts.editEditorial || "Edit Publisher"}>
-                        <Edit className="h-4 w-4" />
+        {filtered.length > 0 ? (
+          <>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{texts.tableHeaderName || 'Name'}</TableHead>
+                  <TableHead>{texts.tableHeaderRut || 'RUT'}</TableHead>
+                  <TableHead>{texts.tableHeaderCelular || 'Cellphone'}</TableHead>
+                  <TableHead>Website</TableHead>
+                  <TableHead className="text-center">{texts.tableHeaderActions || 'Actions'}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {paged.map(editorial => (
+                  <TableRow key={editorial.id}>
+                    <TableCell className="font-medium">{editorial.nombre}</TableCell>
+                    <TableCell>{editorial.rut || '-'}</TableCell>
+                    <TableCell>{editorial.celular || '-'}</TableCell>
+                    <TableCell>
+                      {editorial.sitioWeb ? (
+                        <a href={editorial.sitioWeb} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                          {editorial.sitioWeb}
+                        </a>
+                      ) : '-'}
+                    </TableCell>
+                    <TableCell className="text-center space-x-1">
+                      <Link href={`/${lang}/admin/panel/editorials?action=edit&id=${editorial.id}`} passHref legacyBehavior>
+                        <Button variant="ghost" size="icon" title={texts.editEditorial || 'Edit Publisher'}>
+                          <Edit className="h-4 w-4" />
+                        </Button>
+                      </Link>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        title={texts.deleteButton || 'Delete Publisher'}
+                        onClick={() => setEditorialToDelete(editorial)}
+                        disabled={!editorial.id}
+                      >
+                        <Trash2 className="h-4 w-4 text-destructive" />
                       </Button>
-                    </Link>
-                    <Button variant="ghost" size="icon" title={texts.deleteButton || "Delete Publisher"} onClick={() => setEditorialToDelete(editorial)} disabled={!editorial.id}>
-                      <Trash2 className="h-4 w-4 text-destructive" />
-                    </Button>
-                  </TableCell></TableRow>
-              ))}
-            </TableBody>
-          </Table>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            <div className="flex justify-between items-center mt-4">
+              <p className="text-sm text-muted-foreground">Page {page} of {totalPages}</p>
+              <div className="space-x-2">
+                <Button variant="outline" size="sm" disabled={page === 1} onClick={() => setPage(p => p - 1)}>
+                  Prev
+                </Button>
+                <Button variant="outline" size="sm" disabled={page === totalPages} onClick={() => setPage(p => p + 1)}>
+                  Next
+                </Button>
+              </div>
+            </div>
+          </>
         ) : (
           <div className="text-center py-10 border rounded-md">
             <Building2 className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
-            <p className="text-muted-foreground">{texts.noEditorialsFound || "No publishers found."}</p>
+            <p className="text-muted-foreground">{texts.noEditorialsFound || 'No publishers found.'}</p>
             <Link href={`/${lang}/admin/panel/editorials?action=add`} passHref legacyBehavior>
-                <Button variant="link" className="mt-2">{texts.addNewEditorial || "Add New Publisher"}</Button>
+              <Button variant="link" className="mt-2">{texts.addNewEditorial || 'Add New Publisher'}</Button>
             </Link>
           </div>
         )}
-        
+
         {editorialToDelete && (
           <AlertDialogContent>
             <AlertDialogHeader>
-              <AlertDialogTitle>{texts.deleteConfirmationTitle || "Are you sure?"}</AlertDialogTitle>
+              <AlertDialogTitle>{texts.deleteConfirmationTitle || 'Are you sure?'}</AlertDialogTitle>
               <AlertDialogDescription>
-                {(texts.deleteConfirmationMessage || "This action cannot be undone. This will permanently delete the publisher \"{name}\".").replace('{name}', editorialToDelete.nombre)} {/* Use nombre */}
+                {(texts.deleteConfirmationMessage || 'This action cannot be undone. This will permanently delete the publisher "{name}".').replace('{name}', editorialToDelete.nombre)}
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel onClick={() => setEditorialToDelete(null)}>{texts.cancelButton || "Cancel"}</AlertDialogCancel>
+              <AlertDialogCancel onClick={() => setEditorialToDelete(null)}>{texts.cancelButton || 'Cancel'}</AlertDialogCancel>
               <AlertDialogAction onClick={handleDeleteConfirmation} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
-                {texts.deleteButton || "Delete"}
+                {texts.deleteButton || 'Delete'}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/studio/src/services/api.ts
+++ b/studio/src/services/api.ts
@@ -274,12 +274,28 @@ export const getEditorials = async (
 ): Promise<Editorial[]> => {
   if (API_MODE === 'mock') return mockApi.mockGetEditorials();
 
-  const query = new URLSearchParams(params).toString();
-  const page: Page<Editorial> = await fetchApi<Page<Editorial>>(
-    `/api/editoriales${query ? '?' + query : ''}`,
-  );
+  if (params.page !== undefined || params.size !== undefined) {
+    const query = new URLSearchParams(params).toString();
+    const pageData = await fetchApi<Page<Editorial>>(
+      `/api/editoriales${query ? '?' + query : ''}`,
+    );
+    return pageData.content;
+  }
 
-  return page.content;
+  const firstPage = await fetchApi<Page<Editorial>>('/api/editoriales');
+  let editorials = [...firstPage.content];
+  for (let p = 1; p < firstPage.totalPages; p++) {
+    const query = new URLSearchParams({
+      ...params,
+      page: p,
+      size: firstPage.size,
+    }).toString();
+    const nextPage = await fetchApi<Page<Editorial>>(
+      `/api/editoriales?${query}`,
+    );
+    editorials = editorials.concat(nextPage.content);
+  }
+  return editorials;
 };
 
 export const createEditorial = async (editorialData: Partial<Editorial>): Promise<Editorial> => {


### PR DESCRIPTION
## Summary
- fetch all editorial pages when no params
- paginate editorial admin table with search

## Testing
- `./mvnw -q test` *(fails: unable to access Maven repository)*
- `npm run typecheck` in `studio` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68795588dec08325842176bef0edfdd7